### PR TITLE
fix: `React` is not a type

### DIFF
--- a/src/components/Button.tsx
+++ b/src/components/Button.tsx
@@ -1,4 +1,4 @@
-import type React from "react";
+import React from "react";
 
 import styles from "../styles/modules/button.module.scss";
 

--- a/src/components/Button.tsx
+++ b/src/components/Button.tsx
@@ -1,3 +1,4 @@
+// biome-ignore lint/style/useImportType: React is not a type
 import React from "react";
 
 import styles from "../styles/modules/button.module.scss";


### PR DESCRIPTION
Fixes https://github.com/spicetify/marketplace/issues/782