### PR TITLE
fix: `React` is not a type (continued)

### DIFF
--- a/src/components/Toggle.tsx
+++ b/src/components/Toggle.tsx
@@ -1,4 +1,5 @@
-import type React from "react";
+// biome-ignore lint/style/useImportType: React is not a types
+import React from "react";
 
 import styles from "../styles/modules/toggle.module.scss";
 

--- a/src/components/Toggle.tsx
+++ b/src/components/Toggle.tsx
@@ -1,4 +1,4 @@
-// biome-ignore lint/style/useImportType: React is not a types
+// biome-ignore lint/style/useImportType: React is not a type
 import React from "react";
 
 import styles from "../styles/modules/toggle.module.scss";


### PR DESCRIPTION
Related to Issue #782 and PR #783 

One import in the Toggle.tsx module was still faulty, this PR fixes it

Based on @rxri 's fix on #783 