### PR TITLE
fix: fit dropdown width to longest content

### DIFF
--- a/src/styles/components/_dropdown.scss
+++ b/src/styles/components/_dropdown.scss
@@ -45,6 +45,7 @@ $dropdown-radius: constants.$btn-radius;
     .Dropdown-menu {
       border-top-left-radius: 0;
       border-top-right-radius: 0;
+      width: max-content;
     }
   }
 }


### PR DESCRIPTION
Fit dropdown width to longest content instead of width of the parent
![image](https://github.com/user-attachments/assets/133c6179-cddd-4ba0-b51b-eb45b0cbdb3a)
![image](https://github.com/user-attachments/assets/cb630c88-e09a-49b6-afb1-30b9428a34b6)

Mostly a nitpicking thing, looks kinda silly atm and even clips text in options