### PR TITLE
fix(snippets): make shadow fit the circular art container

### DIFF
--- a/resources/snippets.json
+++ b/resources/snippets.json
@@ -188,7 +188,7 @@
   {
     "title": "Rotating Cover Art",
     "description": "Adds circular mask to cover art and rotation",
-    "code": "@keyframes rotating {from {transform: rotate(0deg);}to {transform: rotate(360deg);}}.cover-art, .main-nowPlayingView-coverArtContainer::after, .main-nowPlayingView-coverArtContainer::before {animation: rotating 10s linear infinite;border-radius: 50%;}.cover-art {clip-path: circle(50% at 50% 50%);} .main-nowPlayingBar-left button {background: transparent;}",
+    "code": "@keyframes rotating {from {transform: rotate(0deg);}to {transform: rotate(360deg);}}.cover-art, .main-nowPlayingView-coverArtContainer::after, .main-nowPlayingView-coverArtContainer::before {animation: rotating 10s linear infinite;border-radius: 50%;}.cover-art {clip-path: circle(50% at 50% 50%);} .main-nowPlayingBar-left button {background: transparent;} .main-nowPlayingView-coverArt {box-shadow:none; filter: drop-shadow(0 9px 9px rgba(0,0,0,.271));}",
     "preview": "resources/assets/snippets/rotating-coverart.png"
   },
   {


### PR DESCRIPTION
Replaces `box-shadow` with `filter: drop-shadow` to fit the clipped artwork shape in the Now Playing sidebar
Before
<img width="309" alt="Screenshot 2025-03-19 at 19 27 36" src="https://github.com/user-attachments/assets/f984766c-f66f-4cc6-827e-941aa0becf05" />
After
<img width="305" alt="Screenshot 2025-03-19 at 19 27 49" src="https://github.com/user-attachments/assets/2ab9eab5-1c19-4d1a-bd82-a9e396cb65c3" />
