### PR TITLE
fix(snippets): remove playlist gradient

### DIFF
--- a/resources/snippets.json
+++ b/resources/snippets.json
@@ -158,7 +158,7 @@
   {
     "title": "Remove Top gradient",
     "description": "Removes gradient from home page and playlist page",
-    "code": ".main-entityHeader-backgroundColor { display: none !important; } .main-actionBarBackground-background { display: none !important; } .main-home-homeHeader { display: none !important; }",
+    "code": ".main-entityHeader-backgroundColor { display: none !important; } .main-actionBarBackground-background { display: none !important; } .main-home-homeHeader { display: none !important; } .playlist-playlist-actionBarBackground-background { display: none !important; }",
     "preview": "resources/assets/snippets/remove-gradient.png"
   },
   {


### PR DESCRIPTION
Remove Top gradient lost some functionality, added a piece to bring functionality back. Specifically, it stopped removing gradients on playlists.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Expanded the “Remove Top gradient” snippet to also hide the gradient bar on playlist pages, providing a cleaner, distraction-free header area across more views.
  - Ensures a more consistent look by removing the playlist action bar gradient along with the top gradient previously removed.
  - Improves visual clarity for users who prefer a minimal interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->