### PR TITLE
fix(snippets): hover effect in `Thicker Bars`

### DIFF
--- a/resources/snippets.json
+++ b/resources/snippets.json
@@ -248,7 +248,7 @@
   {
     "title": "Thicker Bars",
     "description": "Makes the song progress and volume bar thicker",
-    "code": ".x-progressBar-progressBarBg { height: 100% !important; } .x-progressBar-sliderArea { height: 100% !important; } .x-progressBar-fillColor { height: 100% !important; }",
+    "code": ".x-progressBar-progressBarBg { height: 100% !important; } .x-progressBar-sliderArea { height: 100% !important; } .x-progressBar-sliderArea * { height: 100% !important; } .x-progressBar-fillColor { height: 100% !important; }",
     "preview": "resources/assets/snippets/thicker-bars.png"
   },
   {
@@ -458,7 +458,7 @@
   {
     "title": "Rounded Thicker Bars",
     "description": "Makes the progress bar and volume bar thicker and rounded, inspired by Thicker Bars snippet.",
-    "code": ".x-progressBar-progressBarBg { height: 100% !important; --progress-bar-radius: 10px !important;} .x-progressBar-sliderArea { height: 100% !important; } .x-progressBar-fillColor { height: 100% !important; }",
+    "code": ".x-progressBar-progressBarBg { height: 100% !important; --progress-bar-radius: 10px !important;} .x-progressBar-sliderArea { height: 100% !important; } .x-progressBar-sliderArea * { height: 100% !important; } .x-progressBar-fillColor { height: 100% !important; }",
     "preview": "resources/assets/snippets/Rounded-Thicker-Bars.png"
   },
   {


### PR DESCRIPTION

![Fix-Thicker-Bars-Hover](https://github.com/user-attachments/assets/90d2440f-0756-4b04-bf8f-9497d01c0c0d)
Fix the hover preview to be thick too in both the "Thicker Bars" and "Rounded Thicker Bars" snippets.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved height styling consistency for progress bar sliders to ensure uniform display across all child elements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->