### PR TITLE
fix(snippets): improve Lucid Lyrics compatibility in the sidebar

### DIFF
--- a/resources/snippets.json
+++ b/resources/snippets.json
@@ -494,7 +494,7 @@
   {
     "title": "Remove the Artists and Credits sections from the Sidebar",
     "description": "It will only show the album cover and the next song",
-    "code": ".nw2W4ZMdICuBo08Tzxg9 { justify-content: center; height: 100%; width: 100%; } .main-nowPlayingView-section:not(.main-nowPlayingView-queue) {display: none !important}",
+    "code": ".nw2W4ZMdICuBo08Tzxg9 { justify-content: center; height: 100%; width: 100%; } .main-nowPlayingView-section:not(.main-nowPlayingView-queue):not(.lyrics-npv-card) {display: none !important}",
     "preview": "resources/assets/snippets/remove-the-artists-and-credits-sections-from-the-sidebar.png"
   },
   {


### PR DESCRIPTION
Updates the "Remove the Artists and Credits sections from the Sidebar" snippet to stop it from hiding the Lucid Lyrics sidebar card.

**Lucid Lyrics** renders its Now Playing View card as `.main-nowPlayingView-section.lyrics-npv-card`. The snippet hides all `.main-nowPlayingView-section` elements except the queue, so the lyrics card gets hidden too.

This preserves the existing behaviour for Spotify artist/credits sections while allowing **Lucid Lyrics** to stay visible.

## Testing

- Ran `jq empty resources/snippets.json`.
- Used the same selector locally with Spicetify and confirmed Spotify's Now Playing View displays the **Lucid Lyrics** card while other sidebar sections remain hidden.

## Screenshot

<img width="382" height="958" alt="image" src="https://github.com/user-attachments/assets/c0661904-158c-458a-b70c-c1a267d31eab" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Style
* Updated CSS selectors for sidebar component visibility to ensure lyrics sections remain visible while maintaining proper display of now-playing elements and queue items. These refinements improve overall sidebar consistency and visual appearance throughout the application.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/spicetify/marketplace/pull/1154?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->