### PR TITLE
fix(snippets): update `Hide play count`

### DIFF
--- a/resources/snippets.json
+++ b/resources/snippets.json
@@ -284,7 +284,7 @@
   {
     "title": "Hide play count",
     "description": "Hides the play count on songs/albums etc so you can give each songs its chance without thinking about numbers",
-    "code": ".main-trackList-playsHeader,.main-trackList-rowPlayCount {display: none}",
+    "code": ".main-trackList-trackListRow:not(:has(.main-trackList-rowSectionVariable ~ .main-trackList-rowSectionVariable)) .main-trackList-rowSectionVariable {display: none}",
     "preview": "resources/assets/snippets/hide-play-count.png"
   },
   {

--- a/resources/snippets.json
+++ b/resources/snippets.json
@@ -284,7 +284,7 @@
   {
     "title": "Hide play count",
     "description": "Hides the play count on songs/albums etc so you can give each songs its chance without thinking about numbers",
-    "code": ".main-trackList-trackListRow:not(:has(.main-trackList-rowSectionVariable ~ .main-trackList-rowSectionVariable)) .main-trackList-rowSectionVariable {display: none}",
+    "code": ".main-trackList-playsHeader,.main-trackList-rowPlayCount,.main-trackList-trackListRow:not(:has(.main-trackList-rowSectionVariable ~ .main-trackList-rowSectionVariable)) .main-trackList-rowSectionVariable {display: none}",
     "preview": "resources/assets/snippets/hide-play-count.png"
   },
   {


### PR DESCRIPTION
### Problem

The **Hide play count** snippet no longer works on recent Spotify versions (verified on **1.2.93**). Its selectors `.main-trackList-playsHeader` and `.main-trackList-rowPlayCount` no longer exist in the DOM, so the snippet silently does nothing.

Fixes #1026.

### Fix

```css
.main-trackList-trackListRow:not(:has(.main-trackList-rowSectionVariable ~ .main-trackList-rowSectionVariable)) .main-trackList-rowSectionVariable { display: none }
```

Play count now lives in `.main-trackList-rowSectionVariable`. The tricky part: on **playlists** that same variable column also holds the *album* and *date added* columns, so a blanket `display:none` on it wrongly hid those too.

The distinguisher is column count:

- **Album / artist track rows** → exactly **one** variable column (the play count)
- **Playlist rows** → **two** variable columns (album + date added)

So the selector only hides the variable cell in rows that don't contain a second variable sibling. It uses **no build-hashed classes**, so it should be resilient to future updates.

### Verified

| Surface | Result |
|---|---|
| Album tracklist | play count hidden ✅ |
| Artist → Popular | play counts hidden ✅ |
| Playlist (Liked Songs) | album + date added preserved ✅ |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the “Hide play count” snippet to better match the current track list layout.
  * The snippet now conditionally hides play-count section variables so surrounding row information remains correctly visible.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->