### PR TITLE
fix: skip malformed marketplace manifests

### DIFF
--- a/src/components/Card/Card.tsx
+++ b/src/components/Card/Card.tsx
@@ -68,7 +68,7 @@ export class Card extends React.Component<
     Object.assign(this, props);
 
     // Needs to be after Object.assign so an undefined 'tags' field doesn't overwrite the default []
-    this.tags = props.item.tags || [];
+    this.tags = Array.isArray(props.item.tags) ? props.item.tags.filter((tag): tag is string => typeof tag === "string") : [];
     if (props.item.include) this.tags.push(t("grid.externalJS"));
     if (props.item.archived) this.tags.push(t("grid.archived"));
 

--- a/src/components/Grid.tsx
+++ b/src/components/Grid.tsx
@@ -10,7 +10,7 @@ import { fetchAppManifest, fetchCssSnippets, fetchExtensionManifest, fetchThemeM
 import { openModal } from "../logic/LaunchModals";
 import { marketplaceStorage } from "../logic/Storage";
 import { generateSchemesOptions, generateSortOptions, getLocalStorageDataFromKey, injectColourScheme, sortCardItems } from "../logic/Utils";
-import type { CardItem, CardType, Config, SchemeIni, Snippet, TabItemConfig } from "../types/marketplace-types";
+import type { Author, CardItem, CardType, Config, SchemeIni, Snippet, TabItemConfig } from "../types/marketplace-types";
 import Button from "./Button";
 import Card, { type Card as CardClass } from "./Card/Card";
 import DownloadIcon from "./Icons/DownloadIcon";
@@ -109,12 +109,27 @@ class Grid extends React.Component<
    */
   appendCard(item: CardItem | Snippet, type: CardType, activeTab: string) {
     if (activeTab !== this.props.CONFIG.activeTab) return;
+    if (!item || typeof item.title !== "string" || !item.title.trim()) {
+      console.warn("Skipping malformed Marketplace item", item);
+      return;
+    }
+
+    const normalizedItem = {
+      ...item,
+      authors: Array.isArray(item.authors)
+        ? item.authors.filter(
+            (author): author is Author =>
+              !!author && typeof author.name === "string" && author.name.trim().length > 0 && typeof author.url === "string"
+          )
+        : undefined,
+      tags: Array.isArray(item.tags) ? item.tags.filter((tag): tag is string => typeof tag === "string") : undefined
+    } as CardItem | Snippet;
 
     const card = (
       <Card
-        item={item}
+        item={normalizedItem}
         // Set key prop so items don't get stuck when switching tabs
-        key={`${this.props.CONFIG.activeTab}:${item.user}:${item.title}`}
+        key={`${this.props.CONFIG.activeTab}:${normalizedItem.user}:${normalizedItem.title}`}
         CONFIG={this.CONFIG}
         visual={this.props.CONFIG.visual}
         type={type}
@@ -619,13 +634,14 @@ class Grid extends React.Component<
             .filter((card) => {
               const searchValue = this.state.searchValue.trim().toLowerCase();
               const { title, user, authors, tags } = card.props.item;
+              const includesSearch = (value: unknown) => typeof value === "string" && value.toLowerCase().includes(searchValue);
 
               return (
                 !searchValue ||
-                title.toLowerCase().includes(searchValue) ||
-                user?.toLowerCase().includes(searchValue) ||
-                authors?.some((author) => author.name.toLowerCase().includes(searchValue)) ||
-                [...(tags ?? [])]?.some((tag) => tag.toLowerCase().includes(searchValue))
+                includesSearch(title) ||
+                includesSearch(user) ||
+                (Array.isArray(authors) && authors.some((author) => includesSearch(author?.name))) ||
+                (Array.isArray(tags) && tags.some(includesSearch))
               );
             })
             .map((card) => {

--- a/src/logic/FetchRemotes.ts
+++ b/src/logic/FetchRemotes.ts
@@ -5,6 +5,15 @@ import type { CardItem, RepoTopic, Snippet } from "../types/marketplace-types";
 import { marketplaceStorage } from "./Storage";
 import { addToSessionStorage, isBlacklisted, processAuthors } from "./Utils";
 
+const isNonEmptyString = (value: unknown): value is string => typeof value === "string" && value.trim().length > 0;
+
+const stringArray = (value: unknown): string[] => (Array.isArray(value) ? value.filter((item): item is string => typeof item === "string") : []);
+
+const manifestUrl = (value: unknown, user: string, repo: string, branch: string): string => {
+  if (typeof value !== "string" || !value) return "";
+  return value.startsWith("http") ? value : `https://raw.githubusercontent.com/${user}/${repo}/${branch}/${value}`;
+};
+
 // TODO: add sort type, order, etc?
 // https://docs.github.com/en/github/searching-for-information-on-github/searching-on-github/searching-for-repositories#search-by-topic
 // https://docs.github.com/en/rest/reference/search#search-repositories
@@ -125,8 +134,8 @@ export async function fetchExtensionManifest(contents_url: string, branch: strin
     // Manifest is initially parsed
     const parsedManifests: CardItem[] = manifests.reduce((accum, manifest) => {
       // Check if manifest object is designated for Extensions
-      if (manifest?.name && manifest.description && manifest.main) {
-        const selectedBranch = manifest.branch || branch;
+      if (isNonEmptyString(manifest?.name) && isNonEmptyString(manifest.description) && isNonEmptyString(manifest.main)) {
+        const selectedBranch = isNonEmptyString(manifest.branch) ? manifest.branch : branch;
         const item = {
           manifest,
           title: manifest.name,
@@ -136,17 +145,11 @@ export async function fetchExtensionManifest(contents_url: string, branch: strin
           repo,
           branch: selectedBranch,
 
-          imageURL: manifest.preview?.startsWith("http")
-            ? manifest.preview
-            : `https://raw.githubusercontent.com/${user}/${repo}/${selectedBranch}/${manifest.preview}`,
-          extensionURL: manifest.main.startsWith("http")
-            ? manifest.main
-            : `https://raw.githubusercontent.com/${user}/${repo}/${selectedBranch}/${manifest.main}`,
-          readmeURL: manifest.readme?.startsWith("http")
-            ? manifest.readme
-            : `https://raw.githubusercontent.com/${user}/${repo}/${selectedBranch}/${manifest.readme}`,
+          imageURL: manifestUrl(manifest.preview, user, repo, selectedBranch),
+          extensionURL: manifestUrl(manifest.main, user, repo, selectedBranch),
+          readmeURL: manifestUrl(manifest.readme, user, repo, selectedBranch),
           stars,
-          tags: manifest.tags
+          tags: stringArray(manifest.tags)
         };
         // Add to list unless we're hiding installed items and it's installed
         if (!(hideInstalled && marketplaceStorage.getItem(`marketplace:installed:${user}/${repo}/${manifest.main}`))) {
@@ -188,8 +191,8 @@ export async function fetchThemeManifest(contents_url: string, branch: string, s
     // const parsedManifests: ThemeCardItem[] = manifests.reduce((accum, manifest) => {
     const parsedManifests: CardItem[] = manifests.reduce((accum, manifest) => {
       // Check if manifest object is designated for a Theme
-      if (manifest?.name && manifest?.usercss && manifest?.description) {
-        const selectedBranch = manifest.branch || branch;
+      if (isNonEmptyString(manifest?.name) && isNonEmptyString(manifest.usercss) && isNonEmptyString(manifest.description)) {
+        const selectedBranch = isNonEmptyString(manifest.branch) ? manifest.branch : branch;
         const item = {
           manifest,
           title: manifest.name,
@@ -198,25 +201,15 @@ export async function fetchThemeManifest(contents_url: string, branch: string, s
           user,
           repo,
           branch: selectedBranch,
-          imageURL: manifest.preview?.startsWith("http")
-            ? manifest.preview
-            : `https://raw.githubusercontent.com/${user}/${repo}/${selectedBranch}/${manifest.preview}`,
-          readmeURL: manifest.readme?.startsWith("http")
-            ? manifest.readme
-            : `https://raw.githubusercontent.com/${user}/${repo}/${selectedBranch}/${manifest.readme}`,
+          imageURL: manifestUrl(manifest.preview, user, repo, selectedBranch),
+          readmeURL: manifestUrl(manifest.readme, user, repo, selectedBranch),
           stars,
-          tags: manifest.tags,
+          tags: stringArray(manifest.tags),
           // theme stuff
-          cssURL: manifest.usercss.startsWith("http")
-            ? manifest.usercss
-            : `https://raw.githubusercontent.com/${user}/${repo}/${selectedBranch}/${manifest.usercss}`,
+          cssURL: manifestUrl(manifest.usercss, user, repo, selectedBranch),
           // TODO: clean up indentation etc
-          schemesURL: manifest.schemes
-            ? manifest.schemes.startsWith("http")
-              ? manifest.schemes
-              : `https://raw.githubusercontent.com/${user}/${repo}/${selectedBranch}/${manifest.schemes}`
-            : null,
-          include: manifest.include
+          schemesURL: typeof manifest.schemes === "string" ? manifestUrl(manifest.schemes, user, repo, selectedBranch) : null,
+          include: stringArray(manifest.include)
         };
         // If manifest is valid, add it to the list
 
@@ -251,8 +244,8 @@ export async function fetchAppManifest(contents_url: string, branch: string, sta
     // Manifest is initially parsed
     const parsedManifests: CardItem[] = manifests.reduce((accum, manifest) => {
       // Check if manifest object is designated for a Custom App
-      if (manifest?.name && manifest.description && !manifest.main && !manifest.usercss) {
-        const selectedBranch = manifest.branch || branch;
+      if (isNonEmptyString(manifest?.name) && isNonEmptyString(manifest.description) && !manifest.main && !manifest.usercss) {
+        const selectedBranch = isNonEmptyString(manifest.branch) ? manifest.branch : branch;
         // TODO: tweak saved items
         const item = {
           manifest,
@@ -263,18 +256,14 @@ export async function fetchAppManifest(contents_url: string, branch: string, sta
           repo,
           branch: selectedBranch,
 
-          imageURL: manifest.preview?.startsWith("http")
-            ? manifest.preview
-            : `https://raw.githubusercontent.com/${user}/${repo}/${selectedBranch}/${manifest.preview}`,
+          imageURL: manifestUrl(manifest.preview, user, repo, selectedBranch),
           // Custom Apps don't have an entry point; they're just listed so they can link out from the card
           // extensionURL: manifest.main.startsWith("http")
           //   ? manifest.main
           //   : `https://raw.githubusercontent.com/${user}/${repo}/${selectedBranch}/${manifest.main}`,
-          readmeURL: manifest.readme?.startsWith("http")
-            ? manifest.readme
-            : `https://raw.githubusercontent.com/${user}/${repo}/${selectedBranch}/${manifest.readme}`,
+          readmeURL: manifestUrl(manifest.readme, user, repo, selectedBranch),
           stars,
-          tags: manifest.tags
+          tags: stringArray(manifest.tags)
         };
 
         // If manifest is valid, add it to the list

--- a/src/logic/Utils.ts
+++ b/src/logic/Utils.ts
@@ -195,22 +195,17 @@ export const fileToBase64 = (file: File) => {
  * @param user The repo owner
  * @returns The authors, with anything missing added
  */
-export const processAuthors = (authors: Author[], user: string) => {
-  let parsedAuthors: Author[] = [];
+export const processAuthors = (authors: unknown, user: string) => {
+  const parsedAuthors = Array.isArray(authors)
+    ? authors.flatMap((author): Author[] => {
+        if (!author || typeof author !== "object" || typeof author.name !== "string" || !author.name.trim() || typeof author.url !== "string") {
+          return [];
+        }
+        return [{ name: author.name, url: sanitizeUrl(author.url) }];
+      })
+    : [];
 
-  if (authors && authors.length > 0) {
-    parsedAuthors = authors.map((author) => ({
-      name: author.name,
-      url: sanitizeUrl(author.url)
-    }));
-  } else {
-    parsedAuthors.push({
-      name: user,
-      url: `https://github.com/${user}`
-    });
-  }
-
-  return parsedAuthors;
+  return parsedAuthors.length ? parsedAuthors : [{ name: user, url: `https://github.com/${user}` }];
 };
 
 /**

--- a/src/logic/Utils.ts
+++ b/src/logic/Utils.ts
@@ -201,7 +201,12 @@ export const processAuthors = (authors: unknown, user: string) => {
         if (!author || typeof author !== "object" || typeof author.name !== "string" || !author.name.trim() || typeof author.url !== "string") {
           return [];
         }
-        return [{ name: author.name, url: sanitizeUrl(author.url) }];
+        try {
+          return [{ name: author.name, url: sanitizeUrl(author.url) }];
+        } catch (error) {
+          console.warn("Skipping Marketplace author with malformed URL", author, error);
+          return [];
+        }
       })
     : [];
 


### PR DESCRIPTION
## Summary
- validate required manifest strings before constructing cards
- normalize untrusted authors, tags, includes, branches, and asset URLs
- skip malformed cards and make search matching type-safe so one bad listing cannot crash the grid

Fixes #1203.
Fixes #1207.

## Testing
- `pnpm build`
- `pnpm lint` (passes with the existing unused-suppression warning in `Modals/Snippet`)
- live Spotify 1.2.94.583 / Spicetify 2.44.0: loaded all 330 extension cards across both **Load more** requests, then searched the fully loaded grid without reaching the React error boundary
- `pnpm type-check` reports the same six existing errors as a clean `main` checkout; this change adds none

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of incomplete or malformed card, author, tag, and manifest data.
  * Prevented invalid items from appearing in cards and search results.
  * Improved validation and normalization of manifest fields and asset links.
  * Safely filters unsupported tags, branches, and included files.
  * Falls back to repository information when valid author details are unavailable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->