### PR TITLE
fix: validate marketplace manifests with zod

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,8 @@
     "react-dropdown": "^1.11.0",
     "react-i18next": "^17.0.6",
     "react-simple-code-editor": "^0.14.1",
-    "semver": "^7.8.1"
+    "semver": "^7.8.1",
+    "zod": "^4.4.3"
   },
   "devDependencies": {
     "@types/chroma-js": "^3.1.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -38,6 +38,9 @@ importers:
       semver:
         specifier: ^7.8.1
         version: 7.8.1
+      zod:
+        specifier: ^4.4.3
+        version: 4.4.3
     devDependencies:
       '@types/chroma-js':
         specifier: ^3.1.2
@@ -1149,6 +1152,9 @@ packages:
     resolution: {integrity: sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==}
     engines: {node: '>=10'}
 
+  zod@4.4.3:
+    resolution: {integrity: sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==}
+
 snapshots:
 
   '@adobe/css-tools@4.3.3': {}
@@ -2114,3 +2120,5 @@ snapshots:
       string-width: 4.2.3
       y18n: 5.0.8
       yargs-parser: 20.2.9
+
+  zod@4.4.3: {}

--- a/src/logic/FetchRemotes.ts
+++ b/src/logic/FetchRemotes.ts
@@ -121,10 +121,28 @@ async function getRepoManifest(user: string, repo: string, branch: string) {
   const sessionStorageItem = window.sessionStorage.getItem(key);
   const failedSessionStorageItems = JSON.parse(window.sessionStorage.getItem("noManifests") || "[]");
   const url = `https://raw.githubusercontent.com/${user}/${repo}/${branch}/manifest.json`;
-  if (!sessionStorageItem && failedSessionStorageItems.includes(url)) return null;
+  if (!sessionStorageItem && failedSessionStorageItems.includes(url)) return [];
 
-  let manifests = sessionStorageItem ? JSON.parse(sessionStorageItem) : await fetchRepoManifest(url);
-  if (!manifests) return addToSessionStorage([url], "noManifests");
+  let manifests: ReturnType<typeof JSON.parse>;
+  let loadedFromCache = false;
+
+  if (sessionStorageItem) {
+    try {
+      manifests = JSON.parse(sessionStorageItem);
+      loadedFromCache = true;
+    } catch (error) {
+      console.warn(`Invalid cached Marketplace manifest from ${user}/${repo}`, error);
+      window.sessionStorage.removeItem(key);
+      manifests = await fetchRepoManifest(url);
+    }
+  } else {
+    manifests = await fetchRepoManifest(url);
+  }
+
+  if (!manifests) {
+    addToSessionStorage([url], "noManifests");
+    return [];
+  }
   if (!Array.isArray(manifests)) manifests = [manifests];
 
   const parsedManifests = manifests.flatMap((manifest) => {
@@ -134,7 +152,7 @@ async function getRepoManifest(user: string, repo: string, branch: string) {
     return [];
   });
 
-  if (!sessionStorageItem) window.sessionStorage.setItem(key, JSON.stringify(parsedManifests));
+  if (!loadedFromCache) window.sessionStorage.setItem(key, JSON.stringify(parsedManifests));
   return parsedManifests;
 }
 

--- a/src/logic/FetchRemotes.ts
+++ b/src/logic/FetchRemotes.ts
@@ -1,9 +1,41 @@
 import { t } from "i18next";
+import { z } from "zod";
 
 import { BLACKLIST_URL, ITEMS_PER_REQUEST, SNIPPETS_URL } from "../constants";
 import type { CardItem, RepoTopic, Snippet } from "../types/marketplace-types";
 import { marketplaceStorage } from "./Storage";
 import { addToSessionStorage, isBlacklisted, processAuthors } from "./Utils";
+
+const manifestSchema = z
+  .object({
+    name: z.string().trim().min(1),
+    description: z.string().trim().min(1),
+    main: z.string().trim().min(1).optional(),
+    usercss: z.string().trim().min(1).optional(),
+    authors: z
+      .array(
+        z
+          .object({
+            name: z.string().trim().min(1),
+            url: z.url().optional()
+          })
+          .transform(({ name, url }) => ({ name, url: url || `https://github.com/${name}` }))
+      )
+      .catch([]),
+    preview: z
+      .string()
+      .nullish()
+      .transform((preview) => preview || ""),
+    readme: z
+      .string()
+      .nullish()
+      .transform((readme) => readme || ""),
+    tags: z.union([z.array(z.string()), z.string().transform((tag) => [tag])]).catch([]),
+    branch: z.string().trim().min(1).optional(),
+    schemes: z.string().optional(),
+    include: z.array(z.string()).catch([])
+  })
+  .passthrough();
 
 // TODO: add sort type, order, etc?
 // https://docs.github.com/en/github/searching-for-information-on-github/searching-on-github/searching-for-repositories#search-by-topic
@@ -88,19 +120,22 @@ async function getRepoManifest(user: string, repo: string, branch: string) {
   const key = `${user}-${repo}`;
   const sessionStorageItem = window.sessionStorage.getItem(key);
   const failedSessionStorageItems = JSON.parse(window.sessionStorage.getItem("noManifests") || "[]");
-  if (sessionStorageItem) return JSON.parse(sessionStorageItem);
-
   const url = `https://raw.githubusercontent.com/${user}/${repo}/${branch}/manifest.json`;
-  if (failedSessionStorageItems.includes(url)) return null;
+  if (!sessionStorageItem && failedSessionStorageItems.includes(url)) return null;
 
-  let manifest = await fetchRepoManifest(url);
+  let manifests = sessionStorageItem ? JSON.parse(sessionStorageItem) : await fetchRepoManifest(url);
+  if (!manifests) return addToSessionStorage([url], "noManifests");
+  if (!Array.isArray(manifests)) manifests = [manifests];
 
-  if (!manifest) return addToSessionStorage([url], "noManifests");
-  if (!Array.isArray(manifest)) manifest = [manifest];
+  const parsedManifests = manifests.flatMap((manifest) => {
+    const parsed = manifestSchema.safeParse(manifest);
+    if (parsed.success) return [parsed.data];
+    console.warn(`Invalid Marketplace manifest from ${user}/${repo}`, parsed.error);
+    return [];
+  });
 
-  addToSessionStorage(manifest, key);
-
-  return manifest;
+  if (!sessionStorageItem) window.sessionStorage.setItem(key, JSON.stringify(parsedManifests));
+  return parsedManifests;
 }
 
 // TODO: can we add a return type here?


### PR DESCRIPTION
## Summary

- validate cached and fetched remote manifests once at the input boundary with Zod
- keep required identity fields strict while normalizing optional previews, authors, tags, paths, and arrays
- parse multi-manifest repositories entry by entry so one invalid entry does not hide valid siblings
- preserve unknown manifest fields used by installation logic

This replaces #1208 and follows the maintainer feedback there: validation is centralized in `FetchRemotes.ts`; `Grid`, `Card`, and `Utils` are unchanged.

## Validation

- `pnpm install --frozen-lockfile`
- `pnpm build`
- `pnpm exec biome check --line-ending=crlf src/logic/FetchRemotes.ts`
- `git diff --check`
- `pnpm type-check` remains at the same six pre-existing diagnostics as `origin/main`
- live Spotify 1.2.94 / Spicetify 2.44 test loaded every extension page (153 -> 331 -> 367 cards), then searched for Soundalike successfully with no Marketplace React error boundary or runtime exception

Fixes #1203
Fixes #1207

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved repository manifest handling by validating entries and normalizing optional details.
  * Invalid or incomplete manifest entries are now excluded instead of causing processing issues.
  * Corrupted cached manifest data is automatically removed and fetched again.
  * Validated results are cached more consistently for faster, more reliable access.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->