### PR TITLE
fix: use Spotify client locale for translations

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,6 @@
     "@hello-pangea/dnd": "^18.0.1",
     "chroma-js": "^3.2.0",
     "i18next": "^26.3.0",
-    "i18next-browser-languagedetector": "^8.2.0",
     "prismjs": "^1.30.0",
     "react-dropdown": "^1.11.0",
     "react-i18next": "^17.0.6",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,9 +20,6 @@ importers:
       i18next:
         specifier: ^26.3.0
         version: 26.3.0(typescript@6.0.3)
-      i18next-browser-languagedetector:
-        specifier: ^8.2.0
-        version: 8.2.0
       prismjs:
         specifier: ^1.30.0
         version: 1.30.0
@@ -615,9 +612,6 @@ packages:
     resolution: {integrity: sha512-5gs5ytaNjBrh5Ow3zrvdUUY+0VxIuWVL4i9irt6friV+BqdCfmV11CQTWMiBYWHbXhco+J1kHfTOUkePhCDvMA==}
     engines: {node: '>=18'}
     hasBin: true
-
-  i18next-browser-languagedetector@8.2.0:
-    resolution: {integrity: sha512-P+3zEKLnOF0qmiesW383vsLdtQVyKtCNA9cjSoKCppTKPQVfKd2W8hbVo5ZhNJKDqeM7BOcvNoKJOjpHh4Js9g==}
 
   i18next@26.3.0:
     resolution: {integrity: sha512-gHSgGpUXVmuqE2El1W61DmxeyeTlFfZgdJRWMo9jScAn5pu7TuTuiccb1zh3E2J9hEBVGJ23+96x0ieBhfuIHA==}
@@ -1620,10 +1614,6 @@ snapshots:
       void-elements: 3.1.0
 
   husky@9.1.7: {}
-
-  i18next-browser-languagedetector@8.2.0:
-    dependencies:
-      '@babel/runtime': 7.28.4
 
   i18next@26.3.0(typescript@6.0.3):
     optionalDependencies:

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -1,5 +1,4 @@
 import i18n, { t } from "i18next";
-import LanguageDetector from "i18next-browser-languagedetector";
 import React from "react";
 import { initReactI18next, withTranslation } from "react-i18next";
 
@@ -14,14 +13,11 @@ import type { Config, TabItemConfig } from "./types/marketplace-types";
 
 i18n
   .use(initReactI18next) // passes i18n down to react-i18next
-  .use(LanguageDetector)
   .init({
     // the translations
     resources: locales,
-    detection: {
-      order: ["navigator", "htmlTag"]
-    },
-    // lng: "en", // if you're using a language detector, do not define the lng option
+    // Use Spotify's client locale, not the embedded browser's (they can differ)
+    lng: Spicetify.Locale.getLocale(),
     fallbackLng: "en",
     interpolation: {
       escapeValue: false // react already safes from xss => https://www.i18next.com/translation-function/interpolation#unescape


### PR DESCRIPTION
## Summary
- initialize i18next from `Spicetify.Locale.getLocale()`
- remove the browser-language detector and its dependency
- keep the existing English fallback for unsupported locales

## Root cause
The embedded browser locale can differ from the language selected in Spotify, so navigator-based detection can load the wrong Marketplace translations.

## Validation
- `pnpm install --frozen-lockfile`
- `pnpm biome check src/app.tsx package.json`
- `pnpm build:local`
- behavioral harness verified that Spotify locale `zh-CN` is passed directly to i18next without browser detection

The repository's existing TypeScript baseline still reports the same six unrelated errors, and the Windows `pnpm lint:ci` wildcard issue is unchanged.

Closes #1084

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved localization reliability by using the application’s active locale directly.
  * Retained English as a fallback when localized content is unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->