### PR TITLE
fix: use Spotify URI for album-art colors

### DIFF
--- a/src/logic/Utils.ts
+++ b/src/logic/Utils.ts
@@ -414,13 +414,23 @@ export const initColorShiftLoop = (schemes: SchemeIni) => {
   }, 60 * 1000);
 };
 
-export const getColorFromImage = async (image: string) => {
+export const getColorFromUri = async (uri: string): Promise<string | undefined> => {
   let vibrancy = getLocalStorageDataFromKey(LOCALSTORAGE_KEYS.albumArtBasedColorVibrancy);
   // Add a underscore before any uppercase characters, then make the whole string uppercase
   vibrancy = vibrancy.replace(/([A-Z])/g, "_$1").toUpperCase();
-  const colorOptions = await Spicetify.colorExtractor(image);
-  const color = colorOptions[vibrancy];
-  return color.substring(1);
+
+  try {
+    const colorOptions = await Spicetify.colorExtractor(uri);
+    const color = colorOptions?.[vibrancy];
+    if (!color?.startsWith("#")) {
+      console.error(`No album-art color returned for Spotify URI "${uri}"`);
+      return undefined;
+    }
+    return color.substring(1);
+  } catch (error) {
+    console.error(`Failed to extract album-art color for Spotify URI "${uri}"`, error);
+    return undefined;
+  }
 };
 
 export const generateColorPalette = async (mainColor: string, numColors: number) => {
@@ -436,13 +446,13 @@ export const generateColorPalette = async (mainColor: string, numColors: number)
   return colorArray;
 };
 
-async function waitForAlbumArt(): Promise<string | undefined> {
-  // Only return when the album art is loaded
+async function waitForPlayerItem(): Promise<Spicetify.PlayerTrack | undefined> {
   return new Promise((resolve) => {
-    setInterval(() => {
-      const albumArtSrc = Spicetify.Player.data?.item?.metadata?.image_xlarge_url;
-      if (albumArtSrc) {
-        resolve(albumArtSrc);
+    const interval = setInterval(() => {
+      const item = Spicetify.Player.data?.item;
+      if (item) {
+        clearInterval(interval);
+        resolve(item);
       }
     }, 50);
   });
@@ -453,16 +463,17 @@ export const initAlbumArtBasedColor = (scheme: ColourScheme) => {
   // and update the color scheme accordingly
   Spicetify.Player.addEventListener("songchange", async () => {
     await sleep(1000);
-    let albumArtSrc: string | undefined = Spicetify.Player.data?.item?.metadata?.image_xlarge_url;
+    let item: Spicetify.PlayerTrack | undefined = Spicetify.Player.data?.item;
 
-    // If it doesn't exist, wait for it to load
-    if (albumArtSrc === null || albumArtSrc === undefined) {
-      albumArtSrc = await waitForAlbumArt();
+    if (item === null || item === undefined) {
+      item = await waitForPlayerItem();
     }
 
-    if (albumArtSrc) {
+    if (item?.uri && !item.isLocal) {
       const numColors = new Set(Object.values(scheme)).size;
-      const mainColor: string = await getColorFromImage(albumArtSrc);
+      const mainColor = await getColorFromUri(item.uri);
+      if (!mainColor) return;
+
       const newColors = await generateColorPalette(mainColor, numColors);
       /*  Find which keys share the same value in the current scheme, create a new scheme that has the value as the key and all the keys in the old scheme as the value
       i.e.
@@ -497,6 +508,8 @@ export const initAlbumArtBasedColor = (scheme: ColourScheme) => {
         }
       }
       injectColourScheme(newScheme);
+    } else {
+      console.error(`Cannot extract album-art color for unsupported track URI "${item?.uri ?? "unknown"}"`);
     }
   });
 };

--- a/src/logic/Utils.ts
+++ b/src/logic/Utils.ts
@@ -422,7 +422,7 @@ export const getColorFromUri = async (uri: string): Promise<string | undefined> 
   try {
     const colorOptions = await Spicetify.colorExtractor(uri);
     const color = colorOptions?.[vibrancy];
-    if (!color?.startsWith("#")) {
+    if (typeof color !== "string" || !/^#[0-9a-f]{6}$/i.test(color)) {
       console.error(`No album-art color returned for Spotify URI "${uri}"`);
       return undefined;
     }
@@ -448,13 +448,19 @@ export const generateColorPalette = async (mainColor: string, numColors: number)
 
 async function waitForPlayerItem(): Promise<Spicetify.PlayerTrack | undefined> {
   return new Promise((resolve) => {
+    let timeout: ReturnType<typeof setTimeout> | undefined;
     const interval = setInterval(() => {
       const item = Spicetify.Player.data?.item;
       if (item) {
         clearInterval(interval);
+        if (timeout !== undefined) clearTimeout(timeout);
         resolve(item);
       }
     }, 50);
+    timeout = setTimeout(() => {
+      clearInterval(interval);
+      resolve(undefined);
+    }, 10_000);
   });
 }
 

--- a/src/logic/Utils.ts
+++ b/src/logic/Utils.ts
@@ -415,9 +415,9 @@ export const initColorShiftLoop = (schemes: SchemeIni) => {
 };
 
 export const getColorFromUri = async (uri: string): Promise<string | undefined> => {
-  let vibrancy = getLocalStorageDataFromKey(LOCALSTORAGE_KEYS.albumArtBasedColorVibrancy);
+  const storedVibrancy = getLocalStorageDataFromKey(LOCALSTORAGE_KEYS.albumArtBasedColorVibrancy, "PROMINENT");
   // Add a underscore before any uppercase characters, then make the whole string uppercase
-  vibrancy = vibrancy.replace(/([A-Z])/g, "_$1").toUpperCase();
+  const vibrancy = (typeof storedVibrancy === "string" ? storedVibrancy : "PROMINENT").replace(/([A-Z])/g, "_$1").toUpperCase();
 
   try {
     const colorOptions = await Spicetify.colorExtractor(uri);
@@ -451,7 +451,7 @@ async function waitForPlayerItem(): Promise<Spicetify.PlayerTrack | undefined> {
     let timeout: ReturnType<typeof setTimeout> | undefined;
     const interval = setInterval(() => {
       const item = Spicetify.Player.data?.item;
-      if (item) {
+      if (item?.uri) {
         clearInterval(interval);
         if (timeout !== undefined) clearTimeout(timeout);
         resolve(item);
@@ -471,52 +471,50 @@ export const initAlbumArtBasedColor = (scheme: ColourScheme) => {
     await sleep(1000);
     let item: Spicetify.PlayerTrack | undefined = Spicetify.Player.data?.item;
 
-    if (item === null || item === undefined) {
+    if (!item?.uri) {
       item = await waitForPlayerItem();
     }
 
-    if (item?.uri && !item.isLocal) {
-      const numColors = new Set(Object.values(scheme)).size;
-      const mainColor = await getColorFromUri(item.uri);
-      if (!mainColor) return;
+    if (!item?.uri || item.isLocal) return;
 
-      const newColors = await generateColorPalette(mainColor, numColors);
-      /*  Find which keys share the same value in the current scheme, create a new scheme that has the value as the key and all the keys in the old scheme as the value
+    const numColors = new Set(Object.values(scheme)).size;
+    const mainColor = await getColorFromUri(item.uri);
+    if (!mainColor) return;
+
+    const newColors = await generateColorPalette(mainColor, numColors);
+    /*  Find which keys share the same value in the current scheme, create a new scheme that has the value as the key and all the keys in the old scheme as the value
       i.e.
       { "color1": "#000000", "color2": "#000000", "color3": "#FFFFFF" } ->
       { "#000000": ["color1", "color2"], "#FFFFFF": ["color3"]}
       */
-      let colorMap = new Map();
-      for (const [key, value] of Object.entries(scheme)) {
-        if (colorMap.has(value)) {
-          colorMap.get(value).push(key);
-        } else {
-          colorMap.set(value, [key]);
-        }
+    let colorMap = new Map();
+    for (const [key, value] of Object.entries(scheme)) {
+      if (colorMap.has(value)) {
+        colorMap.get(value).push(key);
+      } else {
+        colorMap.set(value, [key]);
       }
-      // Order the color map by how similar the colors are to eachother
-      const orderedColorMap = new Map(
-        [...colorMap.entries()].sort((a, b) => {
-          const aColor = Chroma(a[0]);
-          const bColor = Chroma(b[0]);
-          return aColor.get("lab.l") - bColor.get("lab.l");
-        })
-      );
-      colorMap = orderedColorMap;
-      // replace the keys in the color map with the new colors
-      const newScheme = {};
-      for (const [, value] of colorMap.entries()) {
-        const newColor = newColors.shift();
-        if (newColor) {
-          for (const key of value) {
-            newScheme[key] = newColor;
-          }
-        }
-      }
-      injectColourScheme(newScheme);
-    } else {
-      console.error(`Cannot extract album-art color for unsupported track URI "${item?.uri ?? "unknown"}"`);
     }
+    // Order the color map by how similar the colors are to eachother
+    const orderedColorMap = new Map(
+      [...colorMap.entries()].sort((a, b) => {
+        const aColor = Chroma(a[0]);
+        const bColor = Chroma(b[0]);
+        return aColor.get("lab.l") - bColor.get("lab.l");
+      })
+    );
+    colorMap = orderedColorMap;
+    // replace the keys in the color map with the new colors
+    const newScheme = {};
+    for (const [, value] of colorMap.entries()) {
+      const newColor = newColors.shift();
+      if (newColor) {
+        for (const key of value) {
+          newScheme[key] = newColor;
+        }
+      }
+    }
+    injectColourScheme(newScheme);
   });
 };
 


### PR DESCRIPTION
## Summary
- pass the current Spotify item URI to `Spicetify.colorExtractor`
- skip local or unsupported items
- require complete six-digit hex extractor responses before replacing the active color scheme
- handle null or rejected extractor responses without replacing the current scheme
- bound player-item polling and stop it once metadata is available

## Root cause
The color extractor expects a Spotify item URI, but Marketplace passed `image_xlarge_url`. That produced the reported 403/null response and a follow-up property-access error.

## Validation
- `pnpm install --frozen-lockfile`
- `pnpm biome check src/logic/Utils.ts`
- `pnpm build:local`
- behavioral harness verified Spotify-URI extraction, strict hex validation, image-URL rejection, local-track skipping, null/rejection handling, and bounded polling

The repository's existing TypeScript baseline still reports the same six unrelated errors, and the Windows `pnpm lint:ci` wildcard issue is unchanged.

Closes #1098

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved album-art color detection for supported tracks.
  * Added support for extracting colors from Spotify album-art URIs.
  * Prevented color initialization for local tracks and tracks without available artwork colors.
  * Added safer handling when color extraction fails or artwork is unavailable.
  * Added a timeout to prevent color initialization from waiting indefinitely.
  * Improved handling of unsupported album-art sources and invalid extracted colors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->