### PR TITLE
fix(storage): serialize mutations after hydration

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "@biomejs/biome": "^2.4.13",
     "@hello-pangea/dnd": "^18.0.1",
     "chroma-js": "^3.2.0",
+    "dexie": "^4.4.4",
     "i18next": "^26.3.0",
     "prismjs": "^1.30.0",
     "react-dropdown": "^1.11.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,6 +17,9 @@ importers:
       chroma-js:
         specifier: ^3.2.0
         version: 3.2.0
+      dexie:
+        specifier: ^4.4.4
+        version: 4.4.4
       i18next:
         specifier: ^26.3.0
         version: 26.3.0(typescript@6.0.3)
@@ -102,24 +105,28 @@ packages:
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@biomejs/cli-linux-arm64@2.4.13':
     resolution: {integrity: sha512-NzkUDSqfvMBrPplKgVr3aXLHZ2NEELvvF4vZxXulEylKWIGqlvNEcwUcj9OLrn75TD3lJ/GIqCVlBwd1MZCuYQ==}
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@biomejs/cli-linux-x64-musl@2.4.13':
     resolution: {integrity: sha512-Z601MienRgTBDza/+u2CH3RSrWoXo9rtr8NK6A4KJzqGgfxx+H3VlyLgTJ4sRo40T3pIsqpTmiOQEvYzQvBRvQ==}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@biomejs/cli-linux-x64@2.4.13':
     resolution: {integrity: sha512-Az3ZZedYRBo9EQzNnD9SxFcR1G5QsGo6VEc2hIyVPZ1rdKwee/7E9oeBBZFpE8Z44ekxsDQBqbiWGW5ShOhUSQ==}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@biomejs/cli-win32-arm64@2.4.13':
     resolution: {integrity: sha512-Px9PS2B5/Q183bUwy/5VHqp3J2lzdOCeVGzMpphYfl8oSa7VDCqenBdqWpy6DCy/en4Rbf/Y1RieZF6dJPcc9A==}
@@ -178,36 +185,42 @@ packages:
     engines: {node: '>= 10.0.0'}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@parcel/watcher-linux-arm-musl@2.5.6':
     resolution: {integrity: sha512-Ve3gUCG57nuUUSyjBq/MAM0CzArtuIOxsBdQ+ftz6ho8n7s1i9E1Nmk/xmP323r2YL0SONs1EuwqBp2u1k5fxg==}
     engines: {node: '>= 10.0.0'}
     cpu: [arm]
     os: [linux]
+    libc: [musl]
 
   '@parcel/watcher-linux-arm64-glibc@2.5.6':
     resolution: {integrity: sha512-f2g/DT3NhGPdBmMWYoxixqYr3v/UXcmLOYy16Bx0TM20Tchduwr4EaCbmxh1321TABqPGDpS8D/ggOTaljijOA==}
     engines: {node: '>= 10.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@parcel/watcher-linux-arm64-musl@2.5.6':
     resolution: {integrity: sha512-qb6naMDGlbCwdhLj6hgoVKJl2odL34z2sqkC7Z6kzir8b5W65WYDpLB6R06KabvZdgoHI/zxke4b3zR0wAbDTA==}
     engines: {node: '>= 10.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@parcel/watcher-linux-x64-glibc@2.5.6':
     resolution: {integrity: sha512-kbT5wvNQlx7NaGjzPFu8nVIW1rWqV780O7ZtkjuWaPUgpv2NMFpjYERVi0UYj1msZNyCzGlaCWEtzc+exjMGbQ==}
     engines: {node: '>= 10.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@parcel/watcher-linux-x64-musl@2.5.6':
     resolution: {integrity: sha512-1JRFeC+h7RdXwldHzTsmdtYR/Ku8SylLgTU/reMuqdVD7CtLwf0VR1FqeprZ0eHQkO0vqsbvFLXUmYm/uNKJBg==}
     engines: {node: '>= 10.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@parcel/watcher-win32-arm64@2.5.6':
     resolution: {integrity: sha512-3ukyebjc6eGlw9yRt678DxVF7rjXatWiHvTXqphZLvo7aC5NdEgFufVwjFfY51ijYEWpXbqF5jtrK275z52D4Q==}
@@ -371,6 +384,9 @@ packages:
   detect-libc@2.1.2:
     resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
     engines: {node: '>=8'}
+
+  dexie@4.4.4:
+    resolution: {integrity: sha512-jIwsYI8Os2hgnqc6O49YwFDKGc5v5QjGx0wPVp543ip1F53VFAKMLthV2pQosQcVTv3eAskTWYspOx195PM0FQ==}
 
   eastasianwidth@0.2.0:
     resolution: {integrity: sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==}
@@ -1410,6 +1426,8 @@ snapshots:
 
   detect-libc@2.1.2:
     optional: true
+
+  dexie@4.4.4: {}
 
   eastasianwidth@0.2.0: {}
 

--- a/src/components/Card/Card.tsx
+++ b/src/components/Card/Card.tsx
@@ -441,10 +441,6 @@ export class Card extends React.Component<
     }
   }
 
-  async removeTheme(defaultThemeKey?: string | null) {
-    await queueThemeOperation(() => this.removeThemeNow(defaultThemeKey));
-  }
-
   async installSnippet() {
     console.debug(`Installing snippet ${this.localStorageKey}`);
     await marketplaceStorage.mutateAsync((storage) => {

--- a/src/components/Card/Card.tsx
+++ b/src/components/Card/Card.tsx
@@ -27,6 +27,25 @@ function readStoredStringArray(value: string | undefined): string[] {
   }
 }
 
+type PreparedTheme = {
+  activeScheme: string | null;
+  item: CardItem;
+  parsedSchemes: SchemeIni;
+  record: string;
+  userCSS?: string;
+};
+
+let themeOperationQueue: Promise<void> = Promise.resolve();
+
+function queueThemeOperation<T>(operation: () => Promise<T>) {
+  const result = themeOperationQueue.then(operation);
+  themeOperationQueue = result.then(
+    () => undefined,
+    () => undefined
+  );
+  return result;
+}
+
 export type CardProps = {
   // From `fetchExtensionManifest()`, `fetchThemeManifest()`, and snippets.json
   item: CardItem | Snippet;
@@ -166,26 +185,8 @@ export class Card extends React.Component<
       // Wait for the storage write to persist before offering to reload.
       openModal("RELOAD");
     } else if (this.props.type === "theme") {
-      const themeKey = marketplaceStorage.getItem(LOCALSTORAGE_KEYS.themeInstalled);
-      const previousTheme = themeKey ? getLocalStorageDataFromKey(themeKey, {}) : {};
-
-      if (this.isInstalled()) {
-        console.debug("Theme already installed, removing");
-        await this.removeTheme(this.localStorageKey);
-      } else {
-        const localTheme = marketplaceStorage.getItem(LOCALSTORAGE_KEYS.localTheme);
-        if (localTheme !== null && localTheme.toLowerCase() !== "marketplace") {
-          Spicetify.showNotification(t("notifications.wrongLocalTheme"), true, 5000);
-          return;
-        }
-
-        // Remove theme if already installed, then install the new theme
-        await this.removeTheme();
-        await this.installTheme();
-      }
-
-      // If the new or previous theme has JS, prompt to reload
-      if (this.props.item.manifest?.include || previousTheme.include) openModal("RELOAD");
+      const shouldReload = await this.toggleTheme();
+      if (shouldReload) openModal("RELOAD");
     } else if (this.props.type === "app") {
       // Open repo in new tab
       window.open(this.state.externalUrl, "_blank");
@@ -253,13 +254,12 @@ export class Card extends React.Component<
     }
   }
 
-  async installTheme(update = false) {
-    const { item } = this.props;
+  async prepareTheme(update = false): Promise<PreparedTheme | null> {
+    const item = this.props.item as CardItem;
     if (!item) {
       Spicetify.showNotification(t("notifications.themeInstallationError"), true);
-      return;
+      return null;
     }
-    console.debug(`Installing theme ${this.localStorageKey}`);
 
     let parsedSchemes: SchemeIni = {};
     let currentScheme: string | null = null;
@@ -271,6 +271,7 @@ export class Card extends React.Component<
       currentScheme = activeScheme;
     } else if (item.schemesURL) {
       const schemesResponse = await fetch(item.schemesURL);
+      if (!schemesResponse.ok) throw new Error(`Failed to fetch theme schemes: ${schemesResponse.status}`);
       const colourSchemes = await schemesResponse.text();
       parsedSchemes = parseIni(colourSchemes);
     }
@@ -323,23 +324,32 @@ export class Card extends React.Component<
       lastUpdated,
       created
     });
+
+    let userCSS: string | undefined;
+    if (!item.include) {
+      const tld = window.sessionStorage.getItem("marketplace-request-tld") || undefined;
+      userCSS = await parseCSS(item, tld);
+    }
+
+    return { activeScheme, item, parsedSchemes, record, userCSS };
+  }
+
+  async installPreparedTheme({ activeScheme, item, parsedSchemes, record, userCSS }: PreparedTheme, previousThemeKey?: string | null) {
+    console.debug(`Installing theme ${this.localStorageKey}`);
     await marketplaceStorage.mutateAsync((storage) => {
+      const installedThemes = readStoredStringArray(storage.get(LOCALSTORAGE_KEYS.installedThemes)).filter(
+        (key) => key !== previousThemeKey && key !== this.localStorageKey
+      );
+      if (previousThemeKey && previousThemeKey !== this.localStorageKey) storage.delete(previousThemeKey);
       storage.set(this.localStorageKey, record);
-      const installedThemes = readStoredStringArray(storage.get(LOCALSTORAGE_KEYS.installedThemes));
-      if (!installedThemes.includes(this.localStorageKey)) {
-        storage.set(LOCALSTORAGE_KEYS.installedThemes, JSON.stringify([...installedThemes, this.localStorageKey]));
-        storage.set(LOCALSTORAGE_KEYS.themeInstalled, this.localStorageKey);
-      }
+      storage.set(LOCALSTORAGE_KEYS.installedThemes, JSON.stringify([...installedThemes, this.localStorageKey]));
+      storage.set(LOCALSTORAGE_KEYS.themeInstalled, this.localStorageKey);
     });
 
     console.debug("Installed");
 
-    // TODO: We'll also need to actually update the usercss etc, not just the colour scheme
-    // e.g. the stuff from extension.js, like injectUserCSS() etc.
-
     if (!item.include) {
-      // Add new theme css
-      await this.fetchAndInjectUserCSS(this.localStorageKey);
+      injectUserCSS(userCSS);
       // Update the active theme in Grid state, triggers state change and re-render
       this.props.updateActiveTheme(this.localStorageKey);
       // Update schemes in Grid, triggers state change and re-render
@@ -351,12 +361,53 @@ export class Card extends React.Component<
       if (name) Spicetify.Config.current_theme = name;
       // @ts-expect-error: Cannot assign to 'color_scheme' because it is a read-only property
       if (activeScheme) Spicetify.Config.color_scheme = activeScheme;
+    } else if (previousThemeKey) {
+      injectUserCSS();
+      this.props.updateActiveTheme(null);
+      this.props.updateColourSchemes(null, null);
+      // @ts-expect-error: Cannot assign to 'current_theme' because it is a read-only property
+      Spicetify.Config.current_theme = "marketplace";
+      // @ts-expect-error: Cannot assign to 'color_scheme' because it is a read-only property
+      Spicetify.Config.color_scheme = "marketplace";
     }
 
     this.setState({ installed: true });
   }
 
-  async removeTheme(defaultThemeKey?: string | null) {
+  async installTheme(update = false) {
+    await queueThemeOperation(async () => {
+      const preparedTheme = await this.prepareTheme(update);
+      const activeThemeKey = marketplaceStorage.getItem(LOCALSTORAGE_KEYS.themeInstalled);
+      if (preparedTheme) await this.installPreparedTheme(preparedTheme, activeThemeKey);
+    });
+  }
+
+  async toggleTheme() {
+    return queueThemeOperation(async () => {
+      const themeKey = marketplaceStorage.getItem(LOCALSTORAGE_KEYS.themeInstalled);
+      const previousTheme = themeKey ? getLocalStorageDataFromKey(themeKey, {}) : {};
+
+      if (this.isInstalled()) {
+        console.debug("Theme already installed, removing");
+        await this.removeThemeNow(this.localStorageKey);
+      } else {
+        const localTheme = marketplaceStorage.getItem(LOCALSTORAGE_KEYS.localTheme);
+        if (localTheme !== null && localTheme.toLowerCase() !== "marketplace") {
+          Spicetify.showNotification(t("notifications.wrongLocalTheme"), true, 5000);
+          return false;
+        }
+
+        const preparedTheme = await this.prepareTheme();
+        if (!preparedTheme) return false;
+
+        await this.installPreparedTheme(preparedTheme, themeKey);
+      }
+
+      return Boolean(this.props.item.manifest?.include || previousTheme.include);
+    });
+  }
+
+  async removeThemeNow(defaultThemeKey?: string | null) {
     // If don't specify theme, remove the currently installed theme
     const themeKey = defaultThemeKey || marketplaceStorage.getItem(LOCALSTORAGE_KEYS.themeInstalled);
 
@@ -374,7 +425,7 @@ export class Card extends React.Component<
       console.debug("Removed");
 
       // Removes the current theme CSS
-      await this.fetchAndInjectUserCSS(null);
+      injectUserCSS();
       // Update the active theme in Grid state
       this.props.updateActiveTheme(null);
       // Removes the current colour scheme
@@ -388,6 +439,10 @@ export class Card extends React.Component<
 
       this.setState({ installed: false });
     }
+  }
+
+  async removeTheme(defaultThemeKey?: string | null) {
+    await queueThemeOperation(() => this.removeThemeNow(defaultThemeKey));
   }
 
   installSnippet() {
@@ -425,16 +480,6 @@ export class Card extends React.Component<
     initializeSnippets(remainingInstalledSnippets);
 
     this.setState({ installed: false });
-  }
-
-  /**
-   * Update the user.css in the DOM
-   * @param {string | null} theme The theme localStorageKey or null, if we want to reset the theme
-   */
-  async fetchAndInjectUserCSS(theme) {
-    const tld = window.sessionStorage.getItem("marketplace-request-tld") || undefined;
-    const userCSS = theme ? await parseCSS(this.props.item as CardItem, tld) : undefined;
-    injectUserCSS(userCSS);
   }
 
   openReadme() {

--- a/src/components/Card/Card.tsx
+++ b/src/components/Card/Card.tsx
@@ -94,7 +94,24 @@ export class Card extends React.Component<
     return marketplaceStorage.getItem(this.localStorageKey) !== null;
   }
 
+  handleOperationError(error: unknown) {
+    console.error(`Failed to update ${this.props.type} "${this.props.item.title}"`, error);
+    if (this.props.type === "theme") {
+      Spicetify.showNotification(t("notifications.themeInstallationError"), true);
+    } else if (this.props.type === "extension") {
+      Spicetify.showNotification(t("notifications.extensionInstallationError"), true);
+    }
+  }
+
   async componentDidMount() {
+    try {
+      await this.refreshInstalledItem();
+    } catch (error) {
+      this.handleOperationError(error);
+    }
+  }
+
+  async refreshInstalledItem() {
     // Refresh stars if on "Installed" tab with stars enabled
     if (this.props.CONFIG.activeTab === "Installed" && this.props.type !== "snippet") {
       // https://docs.github.com/en/rest/reference/repos#get-a-repository
@@ -125,6 +142,14 @@ export class Card extends React.Component<
   }
 
   async buttonClicked() {
+    try {
+      await this.performButtonAction();
+    } catch (error) {
+      this.handleOperationError(error);
+    }
+  }
+
+  async performButtonAction() {
     if (this.props.type === "extension") {
       if (this.isInstalled()) {
         console.debug("Extension already installed, removing");
@@ -320,7 +345,7 @@ export class Card extends React.Component<
 
     if (!item.include) {
       // Add new theme css
-      this.fetchAndInjectUserCSS(this.localStorageKey);
+      await this.fetchAndInjectUserCSS(this.localStorageKey);
       // Update the active theme in Grid state, triggers state change and re-render
       this.props.updateActiveTheme(this.localStorageKey);
       // Update schemes in Grid, triggers state change and re-render
@@ -360,7 +385,7 @@ export class Card extends React.Component<
       console.debug("Removed");
 
       // Removes the current theme CSS
-      this.fetchAndInjectUserCSS(null);
+      await this.fetchAndInjectUserCSS(null);
       // Update the active theme in Grid state
       this.props.updateActiveTheme(null);
       // Removes the current colour scheme
@@ -418,13 +443,9 @@ export class Card extends React.Component<
    * @param {string | null} theme The theme localStorageKey or null, if we want to reset the theme
    */
   async fetchAndInjectUserCSS(theme) {
-    try {
-      const tld = window.sessionStorage.getItem("marketplace-request-tld") || undefined;
-      const userCSS = theme ? await parseCSS(this.props.item as CardItem, tld) : undefined;
-      injectUserCSS(userCSS);
-    } catch (error) {
-      console.warn(error);
-    }
+    const tld = window.sessionStorage.getItem("marketplace-request-tld") || undefined;
+    const userCSS = theme ? await parseCSS(this.props.item as CardItem, tld) : undefined;
+    injectUserCSS(userCSS);
   }
 
   openReadme() {

--- a/src/components/Card/Card.tsx
+++ b/src/components/Card/Card.tsx
@@ -17,6 +17,16 @@ import TagsDiv from "./TagsDiv";
 
 const Spicetify = window.Spicetify;
 
+function readStoredStringArray(value: string | undefined): string[] {
+  if (!value) return [];
+  try {
+    const parsed = JSON.parse(value);
+    return Array.isArray(parsed) && parsed.every((item) => typeof item === "string") ? parsed : [];
+  } catch {
+    return [];
+  }
+}
+
 export type CardProps = {
   // From `fetchExtensionManifest()`, `fetchThemeManifest()`, and snippets.json
   item: CardItem | Snippet;
@@ -96,11 +106,7 @@ export class Card extends React.Component<
 
   handleOperationError(error: unknown) {
     console.error(`Failed to update ${this.props.type} "${this.props.item.title}"`, error);
-    if (this.props.type === "theme") {
-      Spicetify.showNotification(t("notifications.themeInstallationError"), true);
-    } else if (this.props.type === "extension") {
-      Spicetify.showNotification(t("notifications.extensionInstallationError"), true);
-    }
+    Spicetify.showNotification(t("notifications.marketplaceOperationError"), true);
   }
 
   async componentDidMount() {
@@ -204,32 +210,29 @@ export class Card extends React.Component<
       return;
     }
     const { manifest, title, subtitle, authors, user, repo, branch, imageURL, extensionURL, readmeURL, lastUpdated, created } = this.props.item;
-    await marketplaceStorage.setItemAsync(
-      this.localStorageKey,
-      JSON.stringify({
-        manifest,
-        type: this.props.type,
-        title,
-        subtitle,
-        authors,
-        user,
-        repo,
-        branch,
-        imageURL,
-        extensionURL,
-        readmeURL,
-        stars: this.state.stars,
-        lastUpdated,
-        created
-      })
-    );
-
-    // Add to installed list if not there already
-    const installedExtensions = getLocalStorageDataFromKey(LOCALSTORAGE_KEYS.installedExtensions, []);
-    if (installedExtensions.indexOf(this.localStorageKey) === -1) {
-      installedExtensions.push(this.localStorageKey);
-      await marketplaceStorage.setItemAsync(LOCALSTORAGE_KEYS.installedExtensions, JSON.stringify(installedExtensions));
-    }
+    const record = JSON.stringify({
+      manifest,
+      type: this.props.type,
+      title,
+      subtitle,
+      authors,
+      user,
+      repo,
+      branch,
+      imageURL,
+      extensionURL,
+      readmeURL,
+      stars: this.state.stars,
+      lastUpdated,
+      created
+    });
+    await marketplaceStorage.mutateAsync((storage) => {
+      storage.set(this.localStorageKey, record);
+      const installedExtensions = readStoredStringArray(storage.get(LOCALSTORAGE_KEYS.installedExtensions));
+      if (!installedExtensions.includes(this.localStorageKey)) {
+        storage.set(LOCALSTORAGE_KEYS.installedExtensions, JSON.stringify([...installedExtensions, this.localStorageKey]));
+      }
+    });
 
     console.debug("Installed");
     this.setState({ installed: true });
@@ -239,13 +242,11 @@ export class Card extends React.Component<
     const extValue = marketplaceStorage.getItem(this.localStorageKey);
     if (extValue) {
       console.debug(`Removing extension ${this.localStorageKey}`);
-      // Remove from localstorage
-      await marketplaceStorage.removeItemAsync(this.localStorageKey);
-
-      // Remove from installed list
-      const installedExtensions = getLocalStorageDataFromKey(LOCALSTORAGE_KEYS.installedExtensions, []);
-      const remainingInstalledExtensions = installedExtensions.filter((key) => key !== this.localStorageKey);
-      await marketplaceStorage.setItemAsync(LOCALSTORAGE_KEYS.installedExtensions, JSON.stringify(remainingInstalledExtensions));
+      await marketplaceStorage.mutateAsync((storage) => {
+        storage.delete(this.localStorageKey);
+        const installedExtensions = readStoredStringArray(storage.get(LOCALSTORAGE_KEYS.installedExtensions));
+        storage.set(LOCALSTORAGE_KEYS.installedExtensions, JSON.stringify(installedExtensions.filter((key) => key !== this.localStorageKey)));
+      });
 
       console.debug("Removed");
       this.setState({ installed: false });
@@ -298,45 +299,38 @@ export class Card extends React.Component<
       created
     } = item;
 
-    await marketplaceStorage.setItemAsync(
-      this.localStorageKey,
-      JSON.stringify({
-        manifest,
-        type: this.props.type,
-        title,
-        subtitle,
-        authors,
-        user,
-        repo,
-        branch,
-        imageURL,
-        extensionURL,
-        readmeURL,
-        stars: this.state.stars,
-        tags: this.tags,
-        // Theme stuff
-        cssURL,
-        schemesURL,
-        include,
-        // Installed theme localstorage item has schemes, nothing else does
-        schemes: parsedSchemes,
-        activeScheme,
-        lastUpdated,
-        created
-      })
-    );
-
-    // TODO: handle this differently?
-
-    // Add to installed list if not there already
-    const installedThemes = getLocalStorageDataFromKey(LOCALSTORAGE_KEYS.installedThemes, []);
-    if (installedThemes.indexOf(this.localStorageKey) === -1) {
-      installedThemes.push(this.localStorageKey);
-      await marketplaceStorage.setItemAsync(LOCALSTORAGE_KEYS.installedThemes, JSON.stringify(installedThemes));
-
-      // const usercssURL = `https://raw.github.com/${this.user}/${this.repo}/${this.branch}/${this.manifest.usercss}`;
-      await marketplaceStorage.setItemAsync(LOCALSTORAGE_KEYS.themeInstalled, this.localStorageKey);
-    }
+    const record = JSON.stringify({
+      manifest,
+      type: this.props.type,
+      title,
+      subtitle,
+      authors,
+      user,
+      repo,
+      branch,
+      imageURL,
+      extensionURL,
+      readmeURL,
+      stars: this.state.stars,
+      tags: this.tags,
+      // Theme stuff
+      cssURL,
+      schemesURL,
+      include,
+      // Installed theme localstorage item has schemes, nothing else does
+      schemes: parsedSchemes,
+      activeScheme,
+      lastUpdated,
+      created
+    });
+    await marketplaceStorage.mutateAsync((storage) => {
+      storage.set(this.localStorageKey, record);
+      const installedThemes = readStoredStringArray(storage.get(LOCALSTORAGE_KEYS.installedThemes));
+      if (!installedThemes.includes(this.localStorageKey)) {
+        storage.set(LOCALSTORAGE_KEYS.installedThemes, JSON.stringify([...installedThemes, this.localStorageKey]));
+        storage.set(LOCALSTORAGE_KEYS.themeInstalled, this.localStorageKey);
+      }
+    });
 
     console.debug("Installed");
 
@@ -370,17 +364,12 @@ export class Card extends React.Component<
 
     if (themeKey && themeValue) {
       console.debug(`Removing theme ${themeKey}`);
-
-      // Remove from localstorage
-      await marketplaceStorage.removeItemAsync(themeKey);
-
-      // Remove record of installed theme
-      await marketplaceStorage.removeItemAsync(LOCALSTORAGE_KEYS.themeInstalled);
-
-      // Remove from installed list
-      const installedThemes = getLocalStorageDataFromKey(LOCALSTORAGE_KEYS.installedThemes, []);
-      const remainingInstalledThemes = installedThemes.filter((key) => key !== themeKey);
-      await marketplaceStorage.setItemAsync(LOCALSTORAGE_KEYS.installedThemes, JSON.stringify(remainingInstalledThemes));
+      await marketplaceStorage.mutateAsync((storage) => {
+        storage.delete(themeKey);
+        storage.delete(LOCALSTORAGE_KEYS.themeInstalled);
+        const installedThemes = readStoredStringArray(storage.get(LOCALSTORAGE_KEYS.installedThemes));
+        storage.set(LOCALSTORAGE_KEYS.installedThemes, JSON.stringify(installedThemes.filter((key) => key !== themeKey)));
+      });
 
       console.debug("Removed");
 

--- a/src/components/Card/Card.tsx
+++ b/src/components/Card/Card.tsx
@@ -21,7 +21,7 @@ function readStoredStringArray(value: string | undefined): string[] {
   if (!value) return [];
   try {
     const parsed = JSON.parse(value);
-    return Array.isArray(parsed) && parsed.every((item) => typeof item === "string") ? parsed : [];
+    return Array.isArray(parsed) ? parsed.filter((item) => typeof item === "string") : [];
   } catch {
     return [];
   }

--- a/src/components/Card/Card.tsx
+++ b/src/components/Card/Card.tsx
@@ -193,9 +193,9 @@ export class Card extends React.Component<
     } else if (this.props.type === "snippet") {
       if (this.isInstalled()) {
         console.debug("Snippet already installed, removing");
-        this.removeSnippet();
+        await this.removeSnippet();
       } else {
-        this.installSnippet();
+        await this.installSnippet();
       }
     } else {
       console.error("Unknown card type");
@@ -445,40 +445,39 @@ export class Card extends React.Component<
     await queueThemeOperation(() => this.removeThemeNow(defaultThemeKey));
   }
 
-  installSnippet() {
+  async installSnippet() {
     console.debug(`Installing snippet ${this.localStorageKey}`);
-    marketplaceStorage.setItem(
-      this.localStorageKey,
-      JSON.stringify({
-        code: this.props.item.code,
-        title: this.props.item.title,
-        description: this.props.item.description,
-        imageURL: this.props.item.imageURL
-      })
-    );
+    await marketplaceStorage.mutateAsync((storage) => {
+      storage.set(
+        this.localStorageKey,
+        JSON.stringify({
+          code: this.props.item.code,
+          title: this.props.item.title,
+          description: this.props.item.description,
+          imageURL: this.props.item.imageURL
+        })
+      );
 
-    // Add to installed list if not there already
+      const installedSnippetKeys = readStoredStringArray(storage.get(LOCALSTORAGE_KEYS.installedSnippets));
+      if (!installedSnippetKeys.includes(this.localStorageKey)) {
+        storage.set(LOCALSTORAGE_KEYS.installedSnippets, JSON.stringify([...installedSnippetKeys, this.localStorageKey]));
+      }
+    });
+
     const installedSnippetKeys = getLocalStorageDataFromKey(LOCALSTORAGE_KEYS.installedSnippets, []);
-    if (installedSnippetKeys.indexOf(this.localStorageKey) === -1) {
-      installedSnippetKeys.push(this.localStorageKey);
-      marketplaceStorage.setItem(LOCALSTORAGE_KEYS.installedSnippets, JSON.stringify(installedSnippetKeys));
-    }
-    const installedSnippets = installedSnippetKeys.map((key) => getLocalStorageDataFromKey(key));
-    initializeSnippets(installedSnippets);
-
+    initializeSnippets(installedSnippetKeys.map((key) => getLocalStorageDataFromKey(key)));
     this.setState({ installed: true });
   }
 
-  removeSnippet() {
-    marketplaceStorage.removeItem(this.localStorageKey);
+  async removeSnippet() {
+    await marketplaceStorage.mutateAsync((storage) => {
+      storage.delete(this.localStorageKey);
+      const installedSnippetKeys = readStoredStringArray(storage.get(LOCALSTORAGE_KEYS.installedSnippets));
+      storage.set(LOCALSTORAGE_KEYS.installedSnippets, JSON.stringify(installedSnippetKeys.filter((key) => key !== this.localStorageKey)));
+    });
 
-    // Remove from installed list
     const installedSnippetKeys = getLocalStorageDataFromKey(LOCALSTORAGE_KEYS.installedSnippets, []);
-    const remainingInstalledSnippetKeys = installedSnippetKeys.filter((key) => key !== this.localStorageKey);
-    marketplaceStorage.setItem(LOCALSTORAGE_KEYS.installedSnippets, JSON.stringify(remainingInstalledSnippetKeys));
-    const remainingInstalledSnippets = remainingInstalledSnippetKeys.map((key) => getLocalStorageDataFromKey(key));
-    initializeSnippets(remainingInstalledSnippets);
-
+    initializeSnippets(installedSnippetKeys.map((key) => getLocalStorageDataFromKey(key)));
     this.setState({ installed: false });
   }
 

--- a/src/components/Card/Card.tsx
+++ b/src/components/Card/Card.tsx
@@ -114,24 +114,25 @@ export class Card extends React.Component<
         console.debug(`New update pushed at: ${pushed_at}`);
         switch (this.props.type) {
           case "extension":
-            this.installExtension();
+            await this.installExtension();
             break;
           case "theme":
-            this.installTheme(true);
+            await this.installTheme(true);
             break;
         }
       }
     }
   }
 
-  buttonClicked() {
+  async buttonClicked() {
     if (this.props.type === "extension") {
       if (this.isInstalled()) {
         console.debug("Extension already installed, removing");
-        this.removeExtension();
+        await this.removeExtension();
       } else {
-        this.installExtension();
+        await this.installExtension();
       }
+      // Wait for the storage write to persist before offering to reload.
       openModal("RELOAD");
     } else if (this.props.type === "theme") {
       const themeKey = marketplaceStorage.getItem(LOCALSTORAGE_KEYS.themeInstalled);
@@ -139,7 +140,7 @@ export class Card extends React.Component<
 
       if (this.isInstalled()) {
         console.debug("Theme already installed, removing");
-        this.removeTheme(this.localStorageKey);
+        await this.removeTheme(this.localStorageKey);
       } else {
         const localTheme = marketplaceStorage.getItem(LOCALSTORAGE_KEYS.localTheme);
         if (localTheme !== null && localTheme.toLowerCase() !== "marketplace") {
@@ -148,8 +149,8 @@ export class Card extends React.Component<
         }
 
         // Remove theme if already installed, then install the new theme
-        this.removeTheme();
-        this.installTheme();
+        await this.removeTheme();
+        await this.installTheme();
       }
 
       // If the new or previous theme has JS, prompt to reload
@@ -169,7 +170,7 @@ export class Card extends React.Component<
     }
   }
 
-  installExtension() {
+  async installExtension() {
     console.debug(`Installing extension ${this.localStorageKey}`);
     // Add to localstorage (this stores a copy of all the card props in the localstorage)
     // TODO: can I clean this up so it's less repetition?
@@ -178,7 +179,7 @@ export class Card extends React.Component<
       return;
     }
     const { manifest, title, subtitle, authors, user, repo, branch, imageURL, extensionURL, readmeURL, lastUpdated, created } = this.props.item;
-    marketplaceStorage.setItem(
+    await marketplaceStorage.setItemAsync(
       this.localStorageKey,
       JSON.stringify({
         manifest,
@@ -202,24 +203,24 @@ export class Card extends React.Component<
     const installedExtensions = getLocalStorageDataFromKey(LOCALSTORAGE_KEYS.installedExtensions, []);
     if (installedExtensions.indexOf(this.localStorageKey) === -1) {
       installedExtensions.push(this.localStorageKey);
-      marketplaceStorage.setItem(LOCALSTORAGE_KEYS.installedExtensions, JSON.stringify(installedExtensions));
+      await marketplaceStorage.setItemAsync(LOCALSTORAGE_KEYS.installedExtensions, JSON.stringify(installedExtensions));
     }
 
     console.debug("Installed");
     this.setState({ installed: true });
   }
 
-  removeExtension() {
+  async removeExtension() {
     const extValue = marketplaceStorage.getItem(this.localStorageKey);
     if (extValue) {
       console.debug(`Removing extension ${this.localStorageKey}`);
       // Remove from localstorage
-      marketplaceStorage.removeItem(this.localStorageKey);
+      await marketplaceStorage.removeItemAsync(this.localStorageKey);
 
       // Remove from installed list
       const installedExtensions = getLocalStorageDataFromKey(LOCALSTORAGE_KEYS.installedExtensions, []);
       const remainingInstalledExtensions = installedExtensions.filter((key) => key !== this.localStorageKey);
-      marketplaceStorage.setItem(LOCALSTORAGE_KEYS.installedExtensions, JSON.stringify(remainingInstalledExtensions));
+      await marketplaceStorage.setItemAsync(LOCALSTORAGE_KEYS.installedExtensions, JSON.stringify(remainingInstalledExtensions));
 
       console.debug("Removed");
       this.setState({ installed: false });
@@ -272,7 +273,7 @@ export class Card extends React.Component<
       created
     } = item;
 
-    marketplaceStorage.setItem(
+    await marketplaceStorage.setItemAsync(
       this.localStorageKey,
       JSON.stringify({
         manifest,
@@ -306,10 +307,10 @@ export class Card extends React.Component<
     const installedThemes = getLocalStorageDataFromKey(LOCALSTORAGE_KEYS.installedThemes, []);
     if (installedThemes.indexOf(this.localStorageKey) === -1) {
       installedThemes.push(this.localStorageKey);
-      marketplaceStorage.setItem(LOCALSTORAGE_KEYS.installedThemes, JSON.stringify(installedThemes));
+      await marketplaceStorage.setItemAsync(LOCALSTORAGE_KEYS.installedThemes, JSON.stringify(installedThemes));
 
       // const usercssURL = `https://raw.github.com/${this.user}/${this.repo}/${this.branch}/${this.manifest.usercss}`;
-      marketplaceStorage.setItem(LOCALSTORAGE_KEYS.themeInstalled, this.localStorageKey);
+      await marketplaceStorage.setItemAsync(LOCALSTORAGE_KEYS.themeInstalled, this.localStorageKey);
     }
 
     console.debug("Installed");
@@ -336,7 +337,7 @@ export class Card extends React.Component<
     this.setState({ installed: true });
   }
 
-  removeTheme(defaultThemeKey?: string | null) {
+  async removeTheme(defaultThemeKey?: string | null) {
     // If don't specify theme, remove the currently installed theme
     const themeKey = defaultThemeKey || marketplaceStorage.getItem(LOCALSTORAGE_KEYS.themeInstalled);
 
@@ -346,15 +347,15 @@ export class Card extends React.Component<
       console.debug(`Removing theme ${themeKey}`);
 
       // Remove from localstorage
-      marketplaceStorage.removeItem(themeKey);
+      await marketplaceStorage.removeItemAsync(themeKey);
 
       // Remove record of installed theme
-      marketplaceStorage.removeItem(LOCALSTORAGE_KEYS.themeInstalled);
+      await marketplaceStorage.removeItemAsync(LOCALSTORAGE_KEYS.themeInstalled);
 
       // Remove from installed list
       const installedThemes = getLocalStorageDataFromKey(LOCALSTORAGE_KEYS.installedThemes, []);
       const remainingInstalledThemes = installedThemes.filter((key) => key !== themeKey);
-      marketplaceStorage.setItem(LOCALSTORAGE_KEYS.installedThemes, JSON.stringify(remainingInstalledThemes));
+      await marketplaceStorage.setItemAsync(LOCALSTORAGE_KEYS.installedThemes, JSON.stringify(remainingInstalledThemes));
 
       console.debug("Removed");
 

--- a/src/extensions/extension.tsx
+++ b/src/extensions/extension.tsx
@@ -116,8 +116,13 @@ import type { RepoType } from "../types/marketplace-types";
     if (existingMarketplaceThemeCSS) existingMarketplaceThemeCSS.remove();
 
     // Add theme css
-    const userCSS = await parseCSS(themeManifest, tld);
-    injectUserCSS(userCSS);
+    // A CSS failure shouldn't stop the theme's included JS from loading below
+    try {
+      const userCSS = await parseCSS(themeManifest, tld);
+      injectUserCSS(userCSS);
+    } catch (error) {
+      console.error("Failed to inject theme CSS", error);
+    }
 
     // Add to Spicetify.Config
     // @ts-expect-error: `current_theme` is read-only type in types

--- a/src/logic/Storage.ts
+++ b/src/logic/Storage.ts
@@ -94,6 +94,7 @@ function mutateStorage(mutate: (draft: Map<string, string>) => void, optimistic 
   }
 
   const operation = enqueue(async () => {
+    await hydrateMarketplaceStorage();
     const previous = new Map(persistedCache);
     const next = new Map(previous);
     mutate(next);

--- a/src/logic/Storage.ts
+++ b/src/logic/Storage.ts
@@ -11,6 +11,7 @@ type StoredRecord = {
 const cache = new Map<string, string>();
 let databasePromise: Promise<IDBDatabase | null> | null = null;
 let hydrationPromise: Promise<void> | null = null;
+let mutationQueue: Promise<void> = Promise.resolve();
 let hydrated = false;
 
 function shouldMigrateLocalStorageKey(key: string) {
@@ -46,9 +47,9 @@ function openDatabase() {
 
 async function runStoreRequest<T>(mode: IDBTransactionMode, run: (store: IDBObjectStore) => IDBRequest<T> | undefined): Promise<T | undefined> {
   const database = await openDatabase();
-  if (!database) return undefined;
+  if (!database) throw new Error("Marketplace IndexedDB storage is unavailable");
 
-  return new Promise((resolve) => {
+  return new Promise((resolve, reject) => {
     const transaction = database.transaction(STORE_NAME, mode);
     const request = run(transaction.objectStore(STORE_NAME));
     let result: T | undefined;
@@ -59,27 +60,71 @@ async function runStoreRequest<T>(mode: IDBTransactionMode, run: (store: IDBObje
       settled = true;
       resolve(value);
     };
+    const fail = (message: string, error: DOMException | null) => {
+      if (settled) return;
+      settled = true;
+      console.warn(message, error);
+      reject(error ?? new Error(message));
+    };
 
     transaction.oncomplete = () => settle(result);
-    transaction.onerror = () => {
-      console.warn("Marketplace IndexedDB transaction failed", transaction.error);
-      settle(undefined);
-    };
-    transaction.onabort = () => {
-      console.warn("Marketplace IndexedDB transaction aborted", transaction.error);
-      settle(undefined);
-    };
+    transaction.onerror = () => fail("Marketplace IndexedDB transaction failed", transaction.error);
+    transaction.onabort = () => fail("Marketplace IndexedDB transaction aborted", transaction.error);
 
     if (!request) return;
 
     request.onsuccess = () => {
       result = request.result;
     };
-    request.onerror = () => {
-      console.warn("Marketplace IndexedDB request failed", request.error);
-      settle(undefined);
-    };
+    request.onerror = () => fail("Marketplace IndexedDB request failed", request.error);
   });
+}
+
+async function persistChanges(previous: Map<string, string>, next: Map<string, string>) {
+  const updates = Array.from(next.entries()).filter(([key, value]) => previous.get(key) !== value);
+  const removals = Array.from(previous.keys()).filter((key) => !next.has(key));
+  if (updates.length === 0 && removals.length === 0) return;
+
+  const database = await openDatabase();
+  if (!database) throw new Error("Marketplace IndexedDB storage is unavailable");
+
+  await new Promise<void>((resolve, reject) => {
+    const transaction = database.transaction(STORE_NAME, "readwrite");
+    const store = transaction.objectStore(STORE_NAME);
+    let settled = false;
+    const fail = (message: string) => {
+      if (settled) return;
+      settled = true;
+      reject(transaction.error ?? new Error(message));
+    };
+
+    transaction.oncomplete = () => {
+      if (settled) return;
+      settled = true;
+      resolve();
+    };
+    transaction.onerror = () => fail("Marketplace IndexedDB transaction failed");
+    transaction.onabort = () => fail("Marketplace IndexedDB transaction aborted");
+
+    for (const [key, value] of updates) store.put({ key, value });
+    for (const key of removals) store.delete(key);
+  });
+}
+
+function mutateStorage(mutate: (draft: Map<string, string>) => void) {
+  const operation = mutationQueue.then(async () => {
+    const previous = new Map(cache);
+    const next = new Map(previous);
+    mutate(next);
+    await persistChanges(previous, next);
+
+    for (const key of previous.keys()) {
+      if (!next.has(key)) cache.delete(key);
+    }
+    for (const [key, value] of next) cache.set(key, value);
+  });
+  mutationQueue = operation.catch(() => undefined);
+  return operation;
 }
 
 async function persistItem(key: string, value: string) {
@@ -145,22 +190,24 @@ export const marketplaceStorage = {
 
   setItem(key: string, value: string) {
     cache.set(key, value);
-    void persistItem(key, value);
+    void persistItem(key, value).catch((error) => console.warn("Marketplace item persistence failed", error));
   },
 
   async setItemAsync(key: string, value: string) {
-    cache.set(key, value);
-    await persistItem(key, value);
+    await mutateStorage((draft) => draft.set(key, value));
   },
 
   removeItem(key: string) {
     cache.delete(key);
-    void removePersistedItem(key);
+    void removePersistedItem(key).catch((error) => console.warn("Marketplace item removal failed", error));
   },
 
   async removeItemAsync(key: string) {
-    cache.delete(key);
-    await removePersistedItem(key);
+    await mutateStorage((draft) => draft.delete(key));
+  },
+
+  async mutateAsync(mutate: (draft: Map<string, string>) => void) {
+    await mutateStorage(mutate);
   },
 
   keys() {

--- a/src/logic/Storage.ts
+++ b/src/logic/Storage.ts
@@ -132,8 +132,12 @@ function mutateStorage(mutate: (draft: Map<string, string>) => void, revision = 
       if ((cacheRevisions.get(key) ?? 0) > revision) continue;
       if (next.has(key)) {
         cache.set(key, next.get(key) as string);
-      } else {
+      } else if (previous.has(key)) {
+        // Only drop keys this mutation actually removed. A cached key the durable
+        // snapshot never had (e.g. a partially failed migration) isn't ours to delete.
         cache.delete(key);
+      } else {
+        continue;
       }
       cacheRevisions.set(key, revision);
     }

--- a/src/logic/Storage.ts
+++ b/src/logic/Storage.ts
@@ -1,6 +1,6 @@
+import Dexie, { type EntityTable } from "dexie";
+
 const DATABASE_NAME = "spicetify-marketplace";
-const DATABASE_VERSION = 1;
-const STORE_NAME = "settings";
 const MARKETPLACE_KEY_PREFIX = "marketplace:";
 
 type StoredRecord = {
@@ -9,109 +9,46 @@ type StoredRecord = {
 };
 
 const cache = new Map<string, string>();
-const durableCache = new Map<string, string>();
+const persistedCache = new Map<string, string>();
 const cacheRevisions = new Map<string, number>();
-let databasePromise: Promise<IDBDatabase | null> | null = null;
+let database: Dexie | null = null;
+let settings: EntityTable<StoredRecord, "key"> | null = null;
+let databaseUnavailable = false;
 let hydrationPromise: Promise<void> | null = null;
 let mutationQueue: Promise<void> = Promise.resolve();
 let mutationRevision = 0;
 let hydrated = false;
 
-function shouldMigrateLocalStorageKey(key: string) {
-  return key.startsWith(MARKETPLACE_KEY_PREFIX);
+function getSettingsTable() {
+  if (databaseUnavailable || !window.indexedDB) return null;
+  if (settings) return settings;
+
+  database = new Dexie(DATABASE_NAME);
+  database.version(1).stores({ settings: "key" });
+  settings = database.table<StoredRecord, "key">("settings") as EntityTable<StoredRecord, "key">;
+  return settings;
 }
 
-function openDatabase() {
-  if (databasePromise) return databasePromise;
-
-  databasePromise = new Promise((resolve) => {
-    if (!window.indexedDB) {
-      resolve(null);
-      return;
-    }
-
-    const request = window.indexedDB.open(DATABASE_NAME, DATABASE_VERSION);
-
-    request.onupgradeneeded = () => {
-      const database = request.result;
-      if (!database.objectStoreNames.contains(STORE_NAME)) database.createObjectStore(STORE_NAME, { keyPath: "key" });
-    };
-
-    request.onsuccess = () => resolve(request.result);
-    request.onerror = () => {
-      console.warn("Marketplace IndexedDB storage unavailable", request.error);
-      resolve(null);
-    };
-    request.onblocked = () => resolve(null);
-  });
-
-  return databasePromise;
+function disableDatabase() {
+  database?.close();
+  database = null;
+  settings = null;
+  databaseUnavailable = true;
 }
 
-async function runStoreRequest<T>(mode: IDBTransactionMode, run: (store: IDBObjectStore) => IDBRequest<T> | undefined): Promise<T | undefined> {
-  const database = await openDatabase();
-  if (!database) throw new Error("Marketplace IndexedDB storage is unavailable");
-
-  return new Promise((resolve, reject) => {
-    const transaction = database.transaction(STORE_NAME, mode);
-    const request = run(transaction.objectStore(STORE_NAME));
-    let result: T | undefined;
-    let settled = false;
-
-    const settle = (value: T | undefined) => {
-      if (settled) return;
-      settled = true;
-      resolve(value);
-    };
-    const fail = (message: string, error: DOMException | null) => {
-      if (settled) return;
-      settled = true;
-      console.warn(message, error);
-      reject(error ?? new Error(message));
-    };
-
-    transaction.oncomplete = () => settle(result);
-    transaction.onerror = () => fail("Marketplace IndexedDB transaction failed", transaction.error);
-    transaction.onabort = () => fail("Marketplace IndexedDB transaction aborted", transaction.error);
-
-    if (!request) return;
-
-    request.onsuccess = () => {
-      result = request.result;
-    };
-    request.onerror = () => fail("Marketplace IndexedDB request failed", request.error);
-  });
+function enqueue(operation: () => Promise<void>) {
+  const result = mutationQueue.then(operation);
+  mutationQueue = result.catch(() => undefined);
+  return result;
 }
 
-async function persistChanges(previous: Map<string, string>, next: Map<string, string>) {
-  const updates = Array.from(next.entries()).filter(([key, value]) => previous.get(key) !== value);
-  const removals = Array.from(previous.keys()).filter((key) => !next.has(key));
-  if (updates.length === 0 && removals.length === 0) return;
-
-  const database = await openDatabase();
-  if (!database) throw new Error("Marketplace IndexedDB storage is unavailable");
-
-  await new Promise<void>((resolve, reject) => {
-    const transaction = database.transaction(STORE_NAME, "readwrite");
-    const store = transaction.objectStore(STORE_NAME);
-    let settled = false;
-    const fail = (message: string) => {
-      if (settled) return;
-      settled = true;
-      reject(transaction.error ?? new Error(message));
-    };
-
-    transaction.oncomplete = () => {
-      if (settled) return;
-      settled = true;
-      resolve();
-    };
-    transaction.onerror = () => fail("Marketplace IndexedDB transaction failed");
-    transaction.onabort = () => fail("Marketplace IndexedDB transaction aborted");
-
-    for (const [key, value] of updates) store.put({ key, value });
-    for (const key of removals) store.delete(key);
-  });
+function changedKeys(previous: Map<string, string>, next: Map<string, string>) {
+  return new Set([
+    ...Array.from(previous.keys()).filter((key) => !next.has(key)),
+    ...Array.from(next.entries())
+      .filter(([key, value]) => previous.get(key) !== value)
+      .map(([key]) => key)
+  ]);
 }
 
 function replaceMap(target: Map<string, string>, source: Map<string, string>) {
@@ -119,70 +56,95 @@ function replaceMap(target: Map<string, string>, source: Map<string, string>) {
   for (const [key, value] of source) target.set(key, value);
 }
 
-function mutateStorage(mutate: (draft: Map<string, string>) => void, revision = ++mutationRevision) {
-  const operation = mutationQueue.then(async () => {
-    const previous = new Map(durableCache);
+function reconcileCache(previous: Map<string, string>, next: Map<string, string>, revision: number) {
+  for (const key of changedKeys(previous, next)) {
+    if ((cacheRevisions.get(key) ?? 0) > revision) continue;
+    if (next.has(key)) cache.set(key, next.get(key) as string);
+    else cache.delete(key);
+    cacheRevisions.set(key, revision);
+  }
+}
+
+async function persistChanges(previous: Map<string, string>, next: Map<string, string>) {
+  const table = getSettingsTable();
+  if (!table || !database) return;
+
+  const updates = Array.from(next.entries())
+    .filter(([key, value]) => previous.get(key) !== value)
+    .map(([key, value]) => ({ key, value }));
+  const removals = Array.from(previous.keys()).filter((key) => !next.has(key));
+  if (updates.length === 0 && removals.length === 0) return;
+
+  await database.transaction("rw", table, async () => {
+    if (updates.length > 0) await table.bulkPut(updates);
+    if (removals.length > 0) await table.bulkDelete(removals);
+  });
+}
+
+function mutateStorage(mutate: (draft: Map<string, string>) => void, optimistic = false) {
+  const revision = ++mutationRevision;
+  let optimisticPrevious: Map<string, string> | null = null;
+  let optimisticNext: Map<string, string> | null = null;
+
+  if (optimistic) {
+    optimisticPrevious = new Map(cache);
+    optimisticNext = new Map(optimisticPrevious);
+    mutate(optimisticNext);
+    reconcileCache(optimisticPrevious, optimisticNext, revision);
+  }
+
+  const operation = enqueue(async () => {
+    const previous = new Map(persistedCache);
     const next = new Map(previous);
     mutate(next);
     await persistChanges(previous, next);
-    replaceMap(durableCache, next);
-
-    const keysToReconcile = new Set([...cache.keys(), ...next.keys()]);
-    for (const key of keysToReconcile) {
-      if ((cacheRevisions.get(key) ?? 0) > revision) continue;
-      if (next.has(key)) {
-        cache.set(key, next.get(key) as string);
-      } else if (previous.has(key)) {
-        // Only drop keys this mutation actually removed. A cached key the durable
-        // snapshot never had (e.g. a partially failed migration) isn't ours to delete.
-        cache.delete(key);
-      } else {
-        continue;
-      }
-      cacheRevisions.set(key, revision);
-    }
+    replaceMap(persistedCache, next);
+    reconcileCache(previous, next, revision);
   });
-  mutationQueue = operation.catch(() => undefined);
-  return operation;
-}
 
-async function persistItem(key: string, value: string) {
-  await runStoreRequest("readwrite", (store) => store.put({ key, value }));
+  if (!optimistic || !optimisticPrevious || !optimisticNext) return operation;
+
+  return operation.catch((error) => {
+    reconcileCache(optimisticNext as Map<string, string>, persistedCache, revision);
+    throw error;
+  });
 }
 
 async function loadIndexedDBCache() {
-  const records = await runStoreRequest<StoredRecord[]>("readonly", (store) => store.getAll());
-  if (!records) return;
+  const table = getSettingsTable();
+  if (!table) return;
 
-  for (const record of records) {
-    cache.set(record.key, record.value);
-    durableCache.set(record.key, record.value);
+  const records = await table.toArray();
+  for (const { key, value } of records) {
+    cache.set(key, value);
+    persistedCache.set(key, value);
   }
 }
 
 async function migrateLocalStorage() {
-  try {
-    const migrated: StoredRecord[] = [];
+  const records: StoredRecord[] = [];
+  for (let index = 0; index < window.localStorage.length; index++) {
+    const key = window.localStorage.key(index);
+    if (!key?.startsWith(MARKETPLACE_KEY_PREFIX) || cache.has(key)) continue;
 
-    for (let index = 0; index < window.localStorage.length; index++) {
-      const key = window.localStorage.key(index);
-      if (!key || !shouldMigrateLocalStorageKey(key) || cache.has(key)) continue;
+    const value = window.localStorage.getItem(key);
+    if (value !== null) records.push({ key, value });
+  }
+  if (records.length === 0) return;
 
-      const value = window.localStorage.getItem(key);
-      if (value === null) continue;
-
-      cache.set(key, value);
-      migrated.push({ key, value });
+  const table = getSettingsTable();
+  if (table) {
+    try {
+      await table.bulkPut(records);
+    } catch (error) {
+      console.warn("Marketplace localStorage migration could not be persisted", error);
+      disableDatabase();
     }
+  }
 
-    await Promise.all(
-      migrated.map(async ({ key, value }) => {
-        await persistItem(key, value);
-        durableCache.set(key, value);
-      })
-    );
-  } catch (error) {
-    console.warn("Marketplace localStorage migration failed", error);
+  for (const { key, value } of records) {
+    cache.set(key, value);
+    persistedCache.set(key, value);
   }
 }
 
@@ -192,20 +154,18 @@ export async function hydrateMarketplaceStorage() {
 
   hydrationPromise = (async () => {
     try {
-      // A failed read must not skip the migration below: if IndexedDB is unavailable we can
-      // still populate the cache from localStorage and stay usable (in-memory) for the session
-      try {
-        await loadIndexedDBCache();
-      } catch (error) {
-        console.warn("Marketplace IndexedDB cache could not be read", error);
-      }
-      await migrateLocalStorage();
-      hydrated = true;
+      await loadIndexedDBCache();
     } catch (error) {
-      console.warn("Marketplace storage hydration failed", error);
-      hydrationPromise = null;
+      console.warn("Marketplace IndexedDB cache could not be read", error);
+      disableDatabase();
     }
-  })();
+
+    await migrateLocalStorage();
+    hydrated = true;
+  })().catch((error) => {
+    console.warn("Marketplace storage hydration failed", error);
+    hydrationPromise = null;
+  });
 
   return hydrationPromise;
 }
@@ -216,10 +176,7 @@ export const marketplaceStorage = {
   },
 
   setItem(key: string, value: string) {
-    const revision = ++mutationRevision;
-    cache.set(key, value);
-    cacheRevisions.set(key, revision);
-    void mutateStorage((draft) => draft.set(key, value), revision).catch((error) => console.warn("Marketplace item persistence failed", error));
+    void mutateStorage((draft) => draft.set(key, value), true).catch((error) => console.warn("Marketplace item persistence failed", error));
   },
 
   async setItemAsync(key: string, value: string) {
@@ -227,10 +184,7 @@ export const marketplaceStorage = {
   },
 
   removeItem(key: string) {
-    const revision = ++mutationRevision;
-    cache.delete(key);
-    cacheRevisions.set(key, revision);
-    void mutateStorage((draft) => draft.delete(key), revision).catch((error) => console.warn("Marketplace item removal failed", error));
+    void mutateStorage((draft) => draft.delete(key), true).catch((error) => console.warn("Marketplace item removal failed", error));
   },
 
   async removeItemAsync(key: string) {

--- a/src/logic/Storage.ts
+++ b/src/logic/Storage.ts
@@ -9,9 +9,12 @@ type StoredRecord = {
 };
 
 const cache = new Map<string, string>();
+const durableCache = new Map<string, string>();
+const cacheRevisions = new Map<string, number>();
 let databasePromise: Promise<IDBDatabase | null> | null = null;
 let hydrationPromise: Promise<void> | null = null;
 let mutationQueue: Promise<void> = Promise.resolve();
+let mutationRevision = 0;
 let hydrated = false;
 
 function shouldMigrateLocalStorageKey(key: string) {
@@ -111,17 +114,29 @@ async function persistChanges(previous: Map<string, string>, next: Map<string, s
   });
 }
 
-function mutateStorage(mutate: (draft: Map<string, string>) => void) {
+function replaceMap(target: Map<string, string>, source: Map<string, string>) {
+  target.clear();
+  for (const [key, value] of source) target.set(key, value);
+}
+
+function mutateStorage(mutate: (draft: Map<string, string>) => void, revision = ++mutationRevision) {
   const operation = mutationQueue.then(async () => {
-    const previous = new Map(cache);
+    const previous = new Map(durableCache);
     const next = new Map(previous);
     mutate(next);
     await persistChanges(previous, next);
+    replaceMap(durableCache, next);
 
-    for (const key of previous.keys()) {
-      if (!next.has(key)) cache.delete(key);
+    const keysToReconcile = new Set([...cache.keys(), ...next.keys()]);
+    for (const key of keysToReconcile) {
+      if ((cacheRevisions.get(key) ?? 0) > revision) continue;
+      if (next.has(key)) {
+        cache.set(key, next.get(key) as string);
+      } else {
+        cache.delete(key);
+      }
+      cacheRevisions.set(key, revision);
     }
-    for (const [key, value] of next) cache.set(key, value);
   });
   mutationQueue = operation.catch(() => undefined);
   return operation;
@@ -131,22 +146,19 @@ async function persistItem(key: string, value: string) {
   await runStoreRequest("readwrite", (store) => store.put({ key, value }));
 }
 
-async function removePersistedItem(key: string) {
-  await runStoreRequest("readwrite", (store) => store.delete(key));
-}
-
 async function loadIndexedDBCache() {
   const records = await runStoreRequest<StoredRecord[]>("readonly", (store) => store.getAll());
   if (!records) return;
 
   for (const record of records) {
     cache.set(record.key, record.value);
+    durableCache.set(record.key, record.value);
   }
 }
 
 async function migrateLocalStorage() {
   try {
-    const migrated: Promise<void>[] = [];
+    const migrated: StoredRecord[] = [];
 
     for (let index = 0; index < window.localStorage.length; index++) {
       const key = window.localStorage.key(index);
@@ -156,10 +168,15 @@ async function migrateLocalStorage() {
       if (value === null) continue;
 
       cache.set(key, value);
-      migrated.push(persistItem(key, value));
+      migrated.push({ key, value });
     }
 
-    await Promise.all(migrated);
+    await Promise.all(
+      migrated.map(async ({ key, value }) => {
+        await persistItem(key, value);
+        durableCache.set(key, value);
+      })
+    );
   } catch (error) {
     console.warn("Marketplace localStorage migration failed", error);
   }
@@ -189,8 +206,10 @@ export const marketplaceStorage = {
   },
 
   setItem(key: string, value: string) {
+    const revision = ++mutationRevision;
     cache.set(key, value);
-    void persistItem(key, value).catch((error) => console.warn("Marketplace item persistence failed", error));
+    cacheRevisions.set(key, revision);
+    void mutateStorage((draft) => draft.set(key, value), revision).catch((error) => console.warn("Marketplace item persistence failed", error));
   },
 
   async setItemAsync(key: string, value: string) {
@@ -198,8 +217,10 @@ export const marketplaceStorage = {
   },
 
   removeItem(key: string) {
+    const revision = ++mutationRevision;
     cache.delete(key);
-    void removePersistedItem(key).catch((error) => console.warn("Marketplace item removal failed", error));
+    cacheRevisions.set(key, revision);
+    void mutateStorage((draft) => draft.delete(key), revision).catch((error) => console.warn("Marketplace item removal failed", error));
   },
 
   async removeItemAsync(key: string) {

--- a/src/logic/Storage.ts
+++ b/src/logic/Storage.ts
@@ -188,7 +188,13 @@ export async function hydrateMarketplaceStorage() {
 
   hydrationPromise = (async () => {
     try {
-      await loadIndexedDBCache();
+      // A failed read must not skip the migration below: if IndexedDB is unavailable we can
+      // still populate the cache from localStorage and stay usable (in-memory) for the session
+      try {
+        await loadIndexedDBCache();
+      } catch (error) {
+        console.warn("Marketplace IndexedDB cache could not be read", error);
+      }
       await migrateLocalStorage();
       hydrated = true;
     } catch (error) {

--- a/src/logic/Utils.ts
+++ b/src/logic/Utils.ts
@@ -416,8 +416,8 @@ export const initColorShiftLoop = (schemes: SchemeIni) => {
 
 export const getColorFromUri = async (uri: string): Promise<string | undefined> => {
   const storedVibrancy = getLocalStorageDataFromKey(LOCALSTORAGE_KEYS.albumArtBasedColorVibrancy, "PROMINENT");
-  // Add a underscore before any uppercase characters, then make the whole string uppercase
-  const vibrancy = (typeof storedVibrancy === "string" ? storedVibrancy : "PROMINENT").replace(/([A-Z])/g, "_$1").toUpperCase();
+  // Convert camelCase settings values to Spicetify's UPPER_SNAKE_CASE keys.
+  const vibrancy = (typeof storedVibrancy === "string" ? storedVibrancy : "PROMINENT").replace(/([a-z])([A-Z])/g, "$1_$2").toUpperCase();
 
   try {
     const colorOptions = await Spicetify.colorExtractor(uri);

--- a/src/logic/Utils.ts
+++ b/src/logic/Utils.ts
@@ -531,7 +531,10 @@ export const parseCSS = async (themeData: CardItem, defaultTld?: string) => {
   const assetsUrl = userCssUrl.replace("/user.css", "/assets/");
 
   console.debug("Parsing CSS: ", userCssUrl);
-  let css = await fetch(`${userCssUrl}?time=${Date.now()}`).then((res) => res.text());
+  const response = await fetch(`${userCssUrl}?time=${Date.now()}`);
+  // Otherwise an error page body gets injected as the theme's CSS
+  if (!response.ok) throw new Error(`Failed to fetch theme CSS (HTTP ${response.status})`);
+  let css = await response.text();
   // console.log("Parsed CSS: ", css);
 
   const urls = css.matchAll(/url\(['|"](?<path>.+?)['|"]\)/gm) || [];

--- a/src/resources/locales/en.json
+++ b/src/resources/locales/en.json
@@ -127,7 +127,8 @@
       "markdownParsingError": "Error parsing markdown (HTTP {{status}})",
       "noReadmeFile": "No README was found",
       "themeInstallationError": "There was an error installing theme",
-      "extensionInstallationError": "There was an error installing extension"
+      "extensionInstallationError": "There was an error installing extension",
+      "marketplaceOperationError": "Marketplace could not complete this operation"
     }
   }
 }


### PR DESCRIPTION
## Summary

- wait for Marketplace storage hydration before capturing mutation state
- prevent an immediate install/remove action from being overwritten by late IndexedDB hydration
- fix extensions and themes reappearing as installed after reload

Closes #1186.

## Root cause

`mutateStorage()` captured `persistedCache` before the queued operation ran. During startup, a user could click install/remove while `hydrateMarketplaceStorage()` was still reading IndexedDB. Hydration then replaced the cache with the old durable snapshot, and the queued mutation cloned that stale snapshot back to IndexedDB.

Mutations now hydrate inside the serialized queue before cloning their previous/next states.

## Verification

- `pnpm biome check src/logic/Storage.ts`
- `pnpm build:local`
- targeted delayed-hydration regression harness: extension record/list removal remains removed in both cache and a fresh IndexedDB connection; concurrent settings writes remain serialized
- live Spotify 1.2.95.453 on macOS with Spicetify 2.44.0: removed Soundalike, accepted reload, confirmed Installed remained empty after reload; reinstalled Soundalike and confirmed it returned with the delete affordance

![Installed extension delete affordance](https://github.com/user-attachments/assets/REPLACE_ME)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added more reliable persistence for installed extensions, themes, and snippets.
  * Added clearer notifications when marketplace operations fail.
  * Improved theme installation, switching, and removal workflows.

* **Bug Fixes**
  * Prevented theme CSS or network errors from blocking related extension functionality.
  * Improved handling of storage updates and recovery when persistence fails.
  * Corrected color setting conversion and CSS request error reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->