### PR TITLE
chore: release 1.0.10

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "marketplace",
-  "version": "1.0.9",
+  "version": "1.0.10",
   "private": true,
   "homepage": "https://github.com/spicetify/marketplace",
   "bugs": {


### PR DESCRIPTION
## Summary

- bump Marketplace from 1.0.9 to 1.0.10
- trigger the existing auto-release workflow for fixes already merged since v1.0.9

## Why

The latest release predates the manifest validation merged in #1209. Release users can therefore still hit the Load More/search crash reported in #1203 and #1207 even though it is fixed on `main`.

## Validation

- `pnpm install --frozen-lockfile`
- `pnpm lint:ci`
- `pnpm build:local`
- live-tested the current `dist` containing #1209 on Spicetify 2.44.0: an active search remained stable while loading the affected extension pages

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the application package to version 1.0.10.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->