### PR TITLE
fix(modals): restore modal chrome Spotify no longer styles

### DIFF
--- a/src/styles/components/_fixes.scss
+++ b/src/styles/components/_fixes.scss
@@ -1,8 +1,93 @@
 /*
+Spicetify's `Spicetify.PopupModal` builds its markup from Spotify's old Track
+Credits modal, inside a <generic-modal> custom element. Spotify has since
+deleted those classes (verified absent as of client 1.2.98), so the modal shell
+renders unstyled: no padding, the close button dropping into normal flow below
+the title, and no scroll container for overflowing content.
+
+These rules restore that chrome. Everything is scoped to <generic-modal> so only
+Spicetify-created modals are affected -- Spotify's own dialogs share
+.GenericModal__overlay, but use a hashed class for the modal box itself.
+
 TODO: can we get this added to the default Spicetify stylesheet?
-It should fix broken extension modals
+It should fix broken extension modals.
 */
 
-.GenericModal {
-  background-color: var(--spice-player);
+$modal-padding: 24px;
+
+generic-modal {
+  .GenericModal {
+    display: flex;
+    max-height: calc(100vh - 64px);
+    border-radius: 8px;
+    background-color: var(--spice-player);
+    overflow: hidden;
+  }
+
+  // Container for `isLarge: false`. Spotify removed its styles outright.
+  // The `isLarge: true` container (.main-embedWidgetGenerator-container) is
+  // still styled by Spotify, so it only needs the flex fix below.
+  .main-trackCreditsModal-container {
+    display: flex;
+    flex-direction: column;
+    width: 524px;
+    max-width: 100%;
+    min-height: 0;
+    color: var(--spice-text);
+  }
+
+  // Lets the scrolling section actually shrink inside the flex column.
+  .main-embedWidgetGenerator-container {
+    min-height: 0;
+  }
+
+  .main-trackCreditsModal-header {
+    display: flex;
+    flex: 0 0 auto;
+    align-items: center;
+    justify-content: space-between;
+    gap: 16px;
+    padding: $modal-padding;
+
+    h1 {
+      margin: 0;
+      font-size: 1.5rem;
+      font-weight: 700;
+      line-height: 1.3;
+    }
+  }
+
+  .main-trackCreditsModal-closeBtn {
+    display: flex;
+    flex: 0 0 auto;
+    align-items: center;
+    justify-content: center;
+    width: 32px;
+    height: 32px;
+    padding: 0;
+    margin-block-start: -8px;
+    margin-inline-end: -8px;
+    border: 0;
+    border-radius: 50%;
+    background-color: transparent;
+    color: rgba(var(--spice-rgb-text), 0.7);
+    cursor: pointer;
+
+    &:hover {
+      color: var(--spice-text);
+      background-color: rgba(var(--spice-rgb-text), 0.1);
+    }
+
+    &:focus-visible {
+      outline: 2px solid var(--spice-text);
+      outline-offset: 2px;
+    }
+  }
+
+  .main-trackCreditsModal-mainSection {
+    flex: 1 1 auto;
+    min-height: 0;
+    overflow-y: auto;
+    padding: 0 $modal-padding $modal-padding;
+  }
 }

--- a/src/styles/components/_fixes.scss
+++ b/src/styles/components/_fixes.scss
@@ -1,13 +1,7 @@
 /*
-Spicetify's `Spicetify.PopupModal` builds its markup from Spotify's old Track
-Credits modal, inside a <generic-modal> custom element. Spotify has since
-deleted those classes (verified absent as of client 1.2.98), so the modal shell
-renders unstyled: no padding, the close button dropping into normal flow below
-the title, and no scroll container for overflowing content.
-
-These rules restore that chrome. Everything is scoped to <generic-modal> so only
-Spicetify-created modals are affected -- Spotify's own dialogs share
-.GenericModal__overlay, but use a hashed class for the modal box itself.
+Spotify deleted the Track Credits modal classes `Spicetify.PopupModal` relies
+on, so the modal shell renders unstyled. These rules restore it, scoped to
+<generic-modal> so Spotify's own dialogs are untouched.
 
 TODO: can we get this added to the default Spicetify stylesheet?
 It should fix broken extension modals.
@@ -24,9 +18,6 @@ generic-modal {
     overflow: hidden;
   }
 
-  // Container for `isLarge: false`. Spotify removed its styles outright.
-  // The `isLarge: true` container (.main-embedWidgetGenerator-container) is
-  // still styled by Spotify, so it only needs the flex fix below.
   .main-trackCreditsModal-container {
     display: flex;
     flex-direction: column;
@@ -36,7 +27,6 @@ generic-modal {
     color: var(--spice-text);
   }
 
-  // Lets the scrolling section actually shrink inside the flex column.
   .main-embedWidgetGenerator-container {
     min-height: 0;
   }


### PR DESCRIPTION
### Problem

`Spicetify.PopupModal` builds its markup from Spotify's old Track Credits modal:

```html
<div class="GenericModal" aria-label="...">
  <div class="main-trackCreditsModal-container">      <!-- or main-embedWidgetGenerator-container -->
    <div class="main-trackCreditsModal-header">
      <h1 class="main-type-alto">Title</h1>
      <button class="main-trackCreditsModal-closeBtn">…</button>
```

Spotify has since deleted most of those classes. Auditing every stylesheet in `xpui/` on client **1.2.98.301**, only two of the seven survive:

| Class | Styled in 1.2.98? |
|---|---|
| `.GenericModal__overlay` | ✅ |
| `.main-embedWidgetGenerator-container` | ✅ |
| `.GenericModal` | ❌ |
| `.main-trackCreditsModal-container` | ❌ |
| `.main-trackCreditsModal-header` | ❌ |
| `.main-trackCreditsModal-closeBtn` | ❌ |
| `.main-trackCreditsModal-mainSection` | ❌ |
| `.main-type-alto` | ❌ |

So every Marketplace modal renders with an unstyled shell: no padding, the close button falling into normal flow *below* the title wearing default `<button>` chrome, an oversized default `h1`, and no scroll container — tall content (Settings) runs straight off the bottom of the window with no way to reach it.

Modals opened with `isLarge: false` are worse still: their container (`.main-trackCreditsModal-container`) has no styles whatsoever, so they get no background, width or radius either.

### Fix

Restore the chrome for the classes Spotify dropped — flex header, borderless round close button, `h1` sizing, a scrolling main section, and a styled small-modal container.

Everything is scoped to the `<generic-modal>` custom element that `PopupModal` appends to `<body>`. That means it fixes **every extension's** modals, not just ours, while provably not reaching Spotify's own dialogs: those share `.GenericModal__overlay`, but the modal box itself now uses a hashed class (`w1gLwZlc_sWpQ3CJ`), not `.GenericModal`.

### Verification

Driven over CDP against a live patched client (`--remote-debugging-port`), measuring computed styles and rects rather than eyeballing:

| | Before | After |
|---|---|---|
| Title / close `y` | stacked | `56` / `52` — same row |
| Close button | default border box | 32×32, `border: 0`, transparent |
| Header | default block | `flex`, `24px` padding |
| Box radius | square | `8px` |
| Content | overflowed off-screen | `overflow-y: auto`, scrolls |
| Box height | full viewport | `885px` in a `949px` viewport |

Also checked the `isLarge: false` shell (524px container, centered, content unclipped) — it coexists with the existing `height: 240px !important` hack in `_reload-modal.scss`, which is left alone here.

`pnpm lint:ci` passes. `pnpm type-check` has two pre-existing failures in `BackupModal` and `LaunchModals`, identical on a clean `main` and unrelated to this CSS-only change.

<img width="741" height="926" alt="SCR-20260904-pzqk" src="https://github.com/user-attachments/assets/7869a3b8-8373-453a-a6f2-a4a17817660c" />


### Note

This is a workaround, and the file's long-standing TODO still stands. The real fix belongs in `spicetifyWrapper.js`, which should emit current class names — Spotify's `main-playlistEditDetailsModal-header` and `-closeBtn` still carry essentially the same rules the dead ones used to. Happy to open that PR against `spicetify/cli` as a follow-up; until it ships and users update their CLI, this keeps Marketplace usable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ds6ryy1Edpg9MS5VcB6Dmc


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Restored consistent styling for popup modals, including spacing, sizing, and layout.
  - Improved modal header presentation with aligned titles and close controls.
  - Added clearer hover and keyboard-focus states for the close button.
  - Improved scrolling behavior for modal content.
  - Ensured large modals fit correctly within the available space and maintain a usable layout.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->